### PR TITLE
Make cgroup generic to work with all docker containers:

### DIFF
--- a/cgroup/getmetrics_cgroup.sh
+++ b/cgroup/getmetrics_cgroup.sh
@@ -2,28 +2,23 @@
 DATADIR='data/'
 cd $DATADIR
 
-for SEARCHKEY in "rubis_apache" "rubis_db"
-do
-apacheweb=$(docker ps --no-trunc | grep $SEARCHKEY | awk '{print $1}')
-if [ -z "$apacheweb" ]
-then
-continue
-else
-echo $apacheweb
-CONTAINER_PID=`docker inspect -f '{{ .State.Pid }}' $apacheweb`
-date +%s%3N | awk '{print "timestamp="$1}' > timestamp.txt & PID1=$!
-cat /cgroup/memory/docker/$apacheweb/memory.usage_in_bytes | awk '{print "MemUsed="$1}' > memmetrics_$SEARCHKEY.txt & PID2=$!
+dockers=$(docker ps --no-trunc | awk '{if(NR!=1)print $1}')
+echo $dockers
+for container in $dockers; do
+    echo "$container"
+    CONTAINER_PID=`docker inspect -f '{{ .State.Pid }}' $container`
+    date +%s%3N | awk '{print "timestamp="$1}' > timestamp.txt & PID1=$!
+    cat /cgroup/memory/docker/$container/memory.usage_in_bytes | awk '{print "MemUsed="$1}' > memmetrics_$container.txt & PID2=$!
+    cat /cgroup/blkio/docker/$container/blkio.throttle.io_service_bytes | grep Read | awk 'BEGIN{readbytes=0} {if(NR!=1){readbytes+=$3}} END{print "DiskRead="readbytes}' > diskmetricsread_$container.txt & PID3=$!
+    cat /cgroup/blkio/docker/$container/blkio.throttle.io_service_bytes | grep Write | awk 'BEGIN{writebytes=0} {if(NR!=1){writebytes+=$3;}} END{print "DiskWrite="writebytes}' > diskmetricswrite_$container.txt & PID4=$!
+    cat /proc/$CONTAINER_PID/net/dev | awk 'BEGIN{rxbytes=0;txbytes=0} {if(NR!=1 && NR!=2){if($1!="lo:"){rxbytes+=$2;txbytes+=$10;}}} END{print "NetworkIn="rxbytes; print "NetworkOut="txbytes}' > networkmetrics_$container.txt & PID5=$!
+    cat /cgroup/cpuacct/docker/$container/cpuacct.stat | awk 'BEGIN{cpu=0} {cpu+=$2} END{print "CPU="cpu}' > cpumetrics_$container.txt & PID6=$!
 
-cat /cgroup/blkio/docker/$apacheweb/blkio.throttle.io_service_bytes | grep Read | awk 'BEGIN{readbytes=0} {if(NR!=1){readbytes+=$3}} END{print "DiskRead="readbytes}' > diskmetricsread_$SEARCHKEY.txt & PID3=$!
-cat /cgroup/blkio/docker/$apacheweb/blkio.throttle.io_service_bytes | grep Write | awk 'BEGIN{writebytes=0} {if(NR!=1){writebytes+=$3;}} END{print "DiskWrite="writebytes}' > diskmetricswrite_$SEARCHKEY.txt & PID4=$!
-cat /proc/$CONTAINER_PID/net/dev | awk 'BEGIN{rxbytes=0;txbytes=0} {if(NR!=1 && NR!=2){if($1!="lo:"){rxbytes+=$2;txbytes+=$10;}}} END{print "NetworkIn="rxbytes; print "NetworkOut="txbytes}' > networkmetrics_$SEARCHKEY.txt & PID5=$!
-cat /cgroup/cpuacct/docker/$apacheweb/cpuacct.stat | awk 'BEGIN{cpu=0} {cpu+=$2} END{print "CPU="cpu}' > cpumetrics_$SEARCHKEY.txt & PID6=$!
-
-wait $PID1
-wait $PID2
-wait $PID3
-wait $PID4
-wait $PID5
-wait $PID6
-fi
+    wait $PID1
+    wait $PID2
+    wait $PID3
+    wait $PID4
+    wait $PID5
+    wait $PID6
 done
+

--- a/cgroup/getmetrics_sys_cgroup.sh
+++ b/cgroup/getmetrics_sys_cgroup.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+DATADIR='data/'
+cd $DATADIR
+
+dockers=$(docker ps --no-trunc | awk '{if(NR!=1)print $1}')
+echo $dockers
+for container in $dockers; do
+    echo "$container"
+    CONTAINER_PID=`docker inspect -f '{{ .State.Pid }}' $container`
+    date +%s%3N | awk '{print "timestamp="$1}' > timestamp.txt & PID1=$!
+    cat /sys/fs/cgroup/memory/system.slice/docker-"$container".scope/memory.usage_in_bytes | awk '{print "MemUsed="$1}' > memmetrics_$container.txt & PID2=$!
+    cat /sys/fs/cgroup/blkio/system.slice/docker-"$container".scope/blkio.throttle.io_service_bytes | grep Read | awk 'BEGIN{readbytes=0} {if(NR!=1){readbytes+=$3}} END{print "DiskRead="readbytes}' > diskmetricsread_$container.txt & PID3=$!
+    cat /sys/fs/cgroup/blkio/system.slice/docker-"$container".scope/blkio.throttle.io_service_bytes | grep Write | awk 'BEGIN{writebytes=0} {if(NR!=1){writebytes+=$3;}} END{print "DiskWrite="writebytes}' > diskmetricswrite_$container.txt & PID4=$!
+    cat /proc/$CONTAINER_PID/net/dev | awk 'BEGIN{rxbytes=0;txbytes=0} {if(NR!=1 && NR!=2){if($1!="lo:"){rxbytes+=$2;txbytes+=$10;}}} END{print "NetworkIn="rxbytes; print "NetworkOut="txbytes}' > networkmetrics_$container.txt & PID5=$!
+    cat /sys/fs/cgroup/cpuacct/system.slice/docker-"$container".scope/cpuacct.stat | awk 'BEGIN{cpu=0} {cpu+=$2} END{print "CPU="cpu}' > cpumetrics_$container.txt & PID6=$!
+
+    wait $PID1
+    wait $PID2
+    wait $PID3
+    wait $PID4
+    wait $PID5
+    wait $PID6
+done
+


### PR DESCRIPTION
Removed tabs and replaced with whitespaces. The cgroup filesystem
can be available in either /cgroup or /sys/fs/cgroup. So depending on the
location seperate scripts are need to fetch data.