### PR TITLE
InsightAgent requires ValuesPercentage. If false, results in "IOError…

### DIFF
--- a/collectd/collectdsample.conf
+++ b/collectd/collectdsample.conf
@@ -336,7 +336,7 @@ LoadPlugin processes
 <Plugin cpu>
   ReportByCpu false
   ReportByState false
-  ValuesPercentage false
+  ValuesPercentage true
 </Plugin>
 #
 <Plugin csv>


### PR DESCRIPTION
…: [Errno 2] No such file or directory: '/opt/collectd/var/lib/collectd/var/lib/collectd/csv/<hostname>/cpu/percent-active-yyyy-mm-dd'"