### PR TITLE
Correct yaml indent

### DIFF
--- a/deployment/DeployAgent/roles/install-script_runner/tasks/main.yml
+++ b/deployment/DeployAgent/roles/install-script_runner/tasks/main.yml
@@ -67,13 +67,13 @@
     owner: root
     group: root
     mode: 0644
- - name: Monit | Copy cleanup script
-   copy:
-     src: files/clean_disk.sh
-     dest: "{{ansible_env.HOME}}/clean_disk.sh"
-     owner: root
-     group: root
-     mode: 0774
+- name: Monit | Copy cleanup script
+  copy:
+    src: files/clean_disk.sh
+    dest: "{{ansible_env.HOME}}/clean_disk.sh"
+    owner: root
+    group: root
+    mode: 0774
 - name: Monit | Restart Monit daemon
   systemd:
     name: monit.service


### PR DESCRIPTION
Correct indent to solve error of running "ansible-playbook insightagent.yaml" :

ERROR! Syntax Error while loading YAML.

The error appears to have been in '/mnt/vmshare/if/InsightAgent/deployment/DeployAgent/roles/install-script_runner/tasks/main.yml': line 70, column 2, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

mode: 0644

    name: Monit | Copy cleanup script
     ^ here
