### PR TITLE
Fix eventPush docker image error.

### DIFF
--- a/event_push/entrypoint.sh
+++ b/event_push/entrypoint.sh
@@ -9,6 +9,7 @@ source venv/bin/activate
 python event_push.py -t
 
 # Run Agent
+echo "Waiting for agent next cron..." > output.log
 nohup python cron.py > nohup.log &
 
 # Stream logs to stdout


### PR DESCRIPTION
Fix the issue posted in slack when running event push docker image:
```bash
tail: cannot open 'output.log' for reading: No such file or directory
```
Slack link: https://insighters-collab.slack.com/archives/C01NTPP7KKM/p1692001273275019