### PR TITLE
Update Kubernetes Agent to support RollingUpdate case.

### DIFF
--- a/kubernetes-agent/tools/instanceMapper.go
+++ b/kubernetes-agent/tools/instanceMapper.go
@@ -125,7 +125,7 @@ func (mapper *InstanceMapper) Update() {
 
 	for namespace, _ := range mapper.Storage {
 		podsCreated, podsDeleted := mapper.GetDiffMap(namespace)
-		targetReplicas := *mapper.KubernetesServer.GetTargetReplicas(namespace)
+		targetReplicas := *mapper.KubernetesServer.GetCurrentReplicas(namespace)
 
 		// Delete pods in slots
 		for resourceKind, resources := range *podsDeleted {


### PR DESCRIPTION
https://insightfinders.atlassian.net/browse/II-16270

Tested with STG:
Both old and new appserver Pods data can be received during RollingUpdate.

<img width="1728" alt="image" src="https://github.com/insightfinder/InsightAgent/assets/50892057/93831a4b-05e6-4e66-87f9-cc86e0789793">
