### PR TITLE
II-18447 Fix kubernetes node instance mapping when new host added.

### DIFF
--- a/kubernetes-agent/host_mapper/hostMapper.go
+++ b/kubernetes-agent/host_mapper/hostMapper.go
@@ -1,6 +1,7 @@
 package host_mapper
 
 import (
+	"gopkg.in/errgo.v2/errors"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"kubernetes-agent/host_mapper/models"
@@ -55,12 +56,12 @@ func (hostMapper *HostMapper) GetHostIndex(host string) int {
 	}
 }
 
-func (hostMapper *HostMapper) GetHostInstanceName(host string) string {
+func (hostMapper *HostMapper) GetHostInstanceName(host string) (string, error) {
 	index := hostMapper.GetHostIndex(host)
 	if index == -1 {
-		return host
+		return host, errors.New("Unable to map host: " + host)
 	} else {
-		return "k8s-host-" + strconv.Itoa(index)
+		return "k8s-host-" + strconv.Itoa(index), nil
 	}
 }
 

--- a/kubernetes-agent/tools/metricData.go
+++ b/kubernetes-agent/tools/metricData.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"fmt"
 	"kubernetes-agent/host_mapper"
 	"kubernetes-agent/insightfinder"
 	"kubernetes-agent/prometheus"
@@ -20,8 +21,16 @@ func BuildMetricDataPayload(metricDataMap *map[string][]prometheus.PromMetricDat
 			var componentName string
 			if promMetricData.Pod == "" && promMetricData.NameSpace == "" {
 				// Node level metric
-				instanceName = hostMapper.GetHostInstanceName(promMetricData.Node)
+				var err error
+				instanceName, err = hostMapper.GetHostInstanceName(promMetricData.Node)
 				componentName = promMetricData.Node
+
+				// Skip the metric data point if the host mapping is failing.
+				if err != nil {
+					fmt.Println(err.Error())
+					continue
+				}
+
 			} else {
 				// Pod level metric
 				instanceName, componentName = instanceNameMapper.GetInstanceMapping(promMetricData.NameSpace, promMetricData.Pod)


### PR DESCRIPTION
https://insightfinders.atlassian.net/browse/II-18447
Add logic to skip sending data if the new node doesn't existing in the host-instance mapping DB.