### PR TITLE
II-19895 AccessParks - Add Airtime 6G metrics to Rukus agent

### DIFF
--- a/ruckus-agent/pkg/models/models.go
+++ b/ruckus-agent/pkg/models/models.go
@@ -52,11 +52,15 @@ type APDetail struct {
 	NumClients                   int     `json:"numClients"`
 	NumClients24G                int     `json:"numClients24G"`
 	NumClients5G                 int     `json:"numClients5G"`
+	NumClients6G                 int     `json:"numClients6G"`
 	Airtime24G                   float64 `json:"airtime24G"`
 	Airtime5G                    float64 `json:"airtime5G"`
+	Airtime6G                    float64 `json:"airtime6G"`
 	ConnectionFailure            float64 `json:"connectionFailure"`
 	IsOverallHealthStatusFlagged bool    `json:"isOverallHealthStatusFlagged"`
 	IsAirtime24GFlagged          bool    `json:"isAirtimeUtilization24GFlagged"`
+	IsAirtime5GFlagged           bool    `json:"isAirtimeUtilization50GFlagged"`
+	IsAirtime6GFlagged           bool    `json:"isAirtimeUtilization6GFlagged"`
 
 	// Performance Fields (High Priority)
 	TxRx       int64 `json:"txRx"`
@@ -64,10 +68,13 @@ type APDetail struct {
 	Rx         int64 `json:"rx"`
 	Noise24G   int   `json:"noise24G"`
 	Noise5G    int   `json:"noise5G"`
+	Noise6G    int   `json:"noise6G"`
 	Retry24G   int64 `json:"retry24G"`
 	Retry5G    int64 `json:"retry5G"`
+	Retry6G    int64 `json:"retry6G"`
 	Latency24G int64 `json:"latency24G"`
 	Latency50G int64 `json:"latency50G"`
+	Latency6G  int64 `json:"latency6G"`
 
 	// Additional useful fields
 	Capacity    int    `json:"capacity"`
@@ -103,11 +110,15 @@ func (ap *APDetail) ToMetricData(componentNameAsAP bool) *MetricData {
 			"Num Clients Total":       ap.NumClients,
 			"Num Clients 24G":         ap.NumClients24G,
 			"Num Clients 5G":          ap.NumClients5G,
+			"Num Clients 6G":          ap.NumClients6G,
 			"Airtime 24G Percent":     ap.Airtime24G,
 			"Airtime 5G Percent":      ap.Airtime5G,
+			"Airtime 6G Percent":      ap.Airtime6G,
 			"Connection Failure Rate": ap.ConnectionFailure,
 			"Is Health Flagged":       ap.IsOverallHealthStatusFlagged,
 			"Is Airtime 24G Flagged":  ap.IsAirtime24GFlagged,
+			"Is Airtime 5G Flagged":   ap.IsAirtime5GFlagged,
+			"Is Airtime 6G Flagged":   ap.IsAirtime6GFlagged,
 			"Alerts Total":            ap.Alerts,
 
 			// === PERFORMANCE FIELDS (High Priority) ===
@@ -116,10 +127,13 @@ func (ap *APDetail) ToMetricData(componentNameAsAP bool) *MetricData {
 			"Rx Bytes Total":         ap.Rx,
 			"Noise 24G Dbm":          ap.Noise24G,
 			"Noise 5G Dbm":           ap.Noise5G,
+			"Noise 6G Dbm":           ap.Noise6G,
 			"Retry 24G Total":        ap.Retry24G,
 			"Retry 5G Total":         ap.Retry5G,
+			"Retry 6G Total":         ap.Retry6G,
 			"Latency 24G Microsec":   ap.Latency24G,
 			"Latency 5G Microsec":    ap.Latency50G,
+			"Latency 6G Microsec":    ap.Latency6G,
 
 			// === CONTEXT FIELDS (Always Include) ===
 			// "Device Name":         cleanDeviceName,


### PR DESCRIPTION
https://insightfinders.atlassian.net/browse/II-19895