### PR TITLE
[II-20181] AccessParks - Stream MCS metrics in Cambium agent

### DIFF
--- a/cambium-agent/cambium/cambium.go
+++ b/cambium-agent/cambium/cambium.go
@@ -707,7 +707,7 @@ func worker(jobs <-chan Job, results chan<- Result) {
 						metricData.Data["RSSI"] = rssiValue
 						metricData.Data["SNR"] = firstValidLink.SNR
 
-						// metricData.Data["RxMCS"] = firstValidLink.RxMCS
+						metricData.Data["RxMCS"] = firstValidLink.RxMCS
 						// metricData.Data["TxMCS"] = firstValidLink.TxMCS
 						// metricData.Data["Link Count"] = linkCount
 

--- a/cambium-agent/models/models.go
+++ b/cambium-agent/models/models.go
@@ -132,15 +132,15 @@ type RadiosResponse struct {
 
 // Link represents a single link in the E2E data
 type Link struct {
-	RSSI int `json:"rssi"`
-	SNR  int `json:"snr"`
+	RSSI  int `json:"rssi"`
+	SNR   int `json:"snr"`
+	RxMCS int `json:"rxMcs"`
 
 	// ZMAC          string `json:"zmac"`
 	// AMAC          string `json:"amac"`
 	// EIRP          int    `json:"eirp"`
 	// LinkAvailable int    `json:"linkAvailable"`
 	// Name          string `json:"name"`
-	// RxMCS         int    `json:"rxMcs"`
 	// TS            int64  `json:"ts"`
 	// TxMCS         int    `json:"txMcs"`
 	// Direction     int    `json:"direction"`


### PR DESCRIPTION
https://insightfinders.atlassian.net/browse/II-20181