### PR TITLE
II-23329 AccessParks - NetExperience agent: Correct the RSSI & SNR metric streaming- Only track 5G devices

### DIFF
--- a/netexperience-agent/README.md
+++ b/netexperience-agent/README.md
@@ -11,8 +11,9 @@ NetExperience Agent is a Go-based data collection agent that fetches network per
 - **Comprehensive Metrics**: Collects AP metrics including:
   - Client counts (5GHz, 2.4GHz, total)
   - Channel utilization per radio
-  - RSSI statistics and thresholds
-  - Client distribution across signal strength levels
+  - RSSI statistics and client distribution across signal strength levels
+  - 5GHz corroboration KPIs: SNR and TX retry rate
+  - **Critical RF indicator**: binary metric combining RSSI, SNR, airtime utilization, and TX retry rate
 
 ## Architecture
 
@@ -63,6 +64,7 @@ netexperience:
   
   # Thresholds
   min_clients_rssi_threshold: 10
+  min_clients_snr_threshold: 10
 
 insightfinder:
   server_url: https://stg.insightfinder.com
@@ -121,6 +123,8 @@ insightfinder:
    - Calculates RSSI statistics and percentages
    - Counts clients per radio band
    - Extracts channel utilization
+   - Computes 5GHz SNR (`rxLastRssi − noiseFloor`) and TX retry rate
+   - Evaluates Critical RF indicator when client thresholds are met
 
 4. **Data Delivery**:
    - Formats metrics for InsightFinder API
@@ -130,20 +134,37 @@ insightfinder:
 ### Metrics Collected
 
 Per equipment (AP):
-- `total_clients`: Total connected clients
-- `clients_5ghz`: Clients on 5GHz band
-- `clients_2_4ghz`: Clients on 2.4GHz band
-- `channel_utilization_5ghz`: 5GHz channel utilization %
-- `channel_utilization_2_4ghz`: 2.4GHz channel utilization %
-- `average_rssi`: Average RSSI across all clients
-- `clients_rssi_below_74`: Count of clients with RSSI < -74 dBm
-- `clients_rssi_below_78`: Count of clients with RSSI < -78 dBm
-- `clients_rssi_below_80`: Count of clients with RSSI < -80 dBm
-- `percent_rssi_below_74`: Percentage of clients with RSSI < -74 dBm
-- `percent_rssi_below_78`: Percentage of clients with RSSI < -78 dBm
-- `percent_rssi_below_80`: Percentage of clients with RSSI < -80 dBm
 
-**Note**: RSSI percentages are only calculated when total clients >= `min_clients_rssi_threshold` (default: 10)
+| Metric | Description | Threshold-gated |
+|---|---|---|
+| `Total Clients` | Total connected clients | — |
+| `Clients 5GHz` | Clients on 5GHz band | — |
+| `Clients 2.4GHz` | Clients on 2.4GHz band | — |
+| `Channel Utilization 5GHz` | 5GHz channel utilization % | — |
+| `Channel Utilization 2.4GHz` | 2.4GHz channel utilization % | — |
+| `Average RSSI` | Average RSSI across all clients (dBm, absolute value) | — |
+| `WAN Port Speed Mbps` | WAN port speed | — |
+| `% Clients RSSI < -74 dBm` | % of clients in orange signal zone | `min_clients_rssi_threshold` |
+| `% Clients RSSI < -78 dBm` | % of clients in red signal zone | `min_clients_rssi_threshold` |
+| `% Clients RSSI < -80 dBm` | % of clients below red signal zone | `min_clients_rssi_threshold` |
+| `SNR 5GHz` | 5GHz SNR: `rxLastRssi − noiseFloor` (dB) | `min_clients_snr_threshold` |
+| `TX Retry Rate 5GHz` | 5GHz TX retry rate: `retries / frames × 100` (%) | `min_clients_snr_threshold` |
+| `Critical RF` | Binary indicator: `1` = critical RF conditions detected, `0` = normal | both thresholds |
+
+Threshold-gated metrics are **omitted entirely** (not sent as zero) when the AP has fewer clients than the configured minimum.
+
+#### Critical RF Logic
+
+`Critical RF` is set to `1` when **all** of the following are true (requires ≥ `min_clients_rssi_threshold` and ≥ `min_clients_snr_threshold` clients):
+
+- **≥ 35% of clients have RSSI < −78 dBm**, AND
+- **at least one 5GHz KPI breaches its critical threshold**:
+
+| KPI | Critical threshold |
+|---|---|
+| Channel Utilization 5GHz | > 85% |
+| SNR 5GHz | < 18 dB |
+| TX Retry Rate 5GHz | > 18% |
 
 ## Rate Limiting
 
@@ -174,6 +195,11 @@ Log level configurable via `agent.log_level`: DEBUG, INFO, WARN, ERROR
 - Ensure customers and equipment are cached (check logs)
 - Verify equipment has recent data in the API
 - Check time range calculation (fromTime/toTime)
+
+### RSSI / SNR / Critical RF metrics missing
+- These are omitted when the AP client count is below the configured threshold
+- Check `min_clients_rssi_threshold` (controls RSSI % and Critical RF) and `min_clients_snr_threshold` (controls SNR, TX Retry Rate, and Critical RF)
+- Default is 10 for both; APs with fewer clients will not emit these metrics
 
 ### Rate Limiting
 - Reduce `equipment_batch_size` if hitting rate limits

--- a/netexperience-agent/README.md
+++ b/netexperience-agent/README.md
@@ -13,24 +13,24 @@ NetExperience Agent is a Go-based data collection agent that fetches network per
   - Channel utilization per radio
   - RSSI statistics and client distribution across signal strength levels
   - 5GHz corroboration KPIs: SNR and TX retry rate
-  - **Critical RF indicator**: binary metric combining RSSI, SNR, airtime utilization, and TX retry rate
+  - **Critical RF indicators**: three separate binary metrics, each pairing the RSSI condition with a different 5GHz KPI threshold
 
 ## Architecture
 
 ```
 netexperience-agent/
 ├── configs/          # Configuration management
-├── insightfinder/    # InsightFinder API client (copied from positron-agent)
+├── insightfinder/    # InsightFinder API client
 ├── netexperience/    # NetExperience API client
 │   ├── netexperience.go  # Authentication and token management
-│   ├── util.go          # API client methods
-│   ├── cache.go         # Cache management
-│   └── type.go          # Type definitions
+│   ├── util.go           # API client methods
+│   ├── cache.go          # Cache management
+│   └── type.go           # Type definitions
 ├── pkg/models/       # Data models
 ├── worker/           # Main processing logic
 │   ├── worker.go     # Worker lifecycle
-│   └── process.go    # Metric processing
-└── main.go          # Entry point
+│   └── process.go    # Metric processing and sending
+└── main.go           # Entry point
 ```
 
 ## Configuration
@@ -62,7 +62,7 @@ netexperience:
   equipment_cache_refresh_hours: 24
   equipment_ip_cache_refresh_hours: 24
   
-  # Thresholds
+  # Thresholds — metrics are omitted entirely when AP client count is below these values
   min_clients_rssi_threshold: 10
   min_clients_snr_threshold: 10
 
@@ -74,7 +74,7 @@ insightfinder:
   sampling_interval: 60
 ```
 
-**Note:** The agent will automatically create the InsightFinder project if it doesn't exist. You don't need to manually create the project in the InsightFinder UI first.
+**Note:** The agent will automatically create the InsightFinder project if it doesn't exist.
 
 ## Installation
 
@@ -100,7 +100,7 @@ insightfinder:
 
 ### Authentication Flow
 
-1. **Initial Login**: Agent logs in using username/password to get access token
+1. **Initial Login**: Agent logs in using username/password to get an access token
 2. **Token Refresh**: Token is automatically refreshed every 23 hours
 3. **Retry Mechanism**: Failed requests trigger token refresh or re-login
 4. **Fallback**: If refresh fails, agent re-authenticates from scratch
@@ -124,7 +124,7 @@ insightfinder:
    - Counts clients per radio band
    - Extracts channel utilization
    - Computes 5GHz SNR (`rxLastRssi − noiseFloor`) and TX retry rate
-   - Evaluates Critical RF indicator when client thresholds are met
+   - Evaluates Critical RF indicators when client thresholds are met
 
 4. **Data Delivery**:
    - Formats metrics for InsightFinder API
@@ -136,7 +136,7 @@ insightfinder:
 Per equipment (AP):
 
 | Metric | Description | Threshold-gated |
-|---|---|---|
+|--------|-------------|-----------------|
 | `Total Clients` | Total connected clients | — |
 | `Clients 5GHz` | Clients on 5GHz band | — |
 | `Clients 2.4GHz` | Clients on 2.4GHz band | — |
@@ -149,28 +149,29 @@ Per equipment (AP):
 | `% Clients RSSI < -80 dBm` | % of clients below red signal zone | `min_clients_rssi_threshold` |
 | `SNR 5GHz` | 5GHz SNR: `rxLastRssi − noiseFloor` (dB) | `min_clients_snr_threshold` |
 | `TX Retry Rate 5GHz` | 5GHz TX retry rate: `retries / frames × 100` (%) | `min_clients_snr_threshold` |
-| `Critical RF` | Binary indicator: `1` = critical RF conditions detected, `0` = normal | both thresholds |
+| `≥ 35% of clients RSSI < -78 dBm AND SNR/SINR < 18 dB` | Critical RF binary indicator | both thresholds |
+| `≥ 35% of clients RSSI < -78 dBm AND Airtime Utilization > 85%` | Critical RF binary indicator | `min_clients_rssi_threshold` |
+| `≥ 35% of clients RSSI < -78 dBm AND TX Retry Rate > 18%` | Critical RF binary indicator | both thresholds |
 
 Threshold-gated metrics are **omitted entirely** (not sent as zero) when the AP has fewer clients than the configured minimum.
 
-#### Critical RF Logic
+### Critical RF Indicators
 
-`Critical RF` is set to `1` when **all** of the following are true (requires ≥ `min_clients_rssi_threshold` and ≥ `min_clients_snr_threshold` clients):
+Each indicator is `1` when its specific pair of conditions is simultaneously true, otherwise `0`. They are evaluated independently — multiple can fire at once.
 
-- **≥ 35% of clients have RSSI < −78 dBm**, AND
-- **at least one 5GHz KPI breaches its critical threshold**:
+The RSSI condition is always: **≥ 35% of clients have RSSI < −78 dBm** (requires ≥ `min_clients_rssi_threshold` clients).
 
-| KPI | Critical threshold |
-|---|---|
-| Channel Utilization 5GHz | > 85% |
-| SNR 5GHz | < 18 dB |
-| TX Retry Rate 5GHz | > 18% |
+| Metric name sent to InsightFinder | Paired KPI condition | Additional threshold |
+|-----------------------------------|----------------------|----------------------|
+| `≥ 35% of clients RSSI < -78 dBm AND SNR/SINR < 18 dB` | SNR 5GHz < 18 dB | `min_clients_snr_threshold` |
+| `≥ 35% of clients RSSI < -78 dBm AND Airtime Utilization > 85%` | Channel Utilization 5GHz > 85% | — |
+| `≥ 35% of clients RSSI < -78 dBm AND TX Retry Rate > 18%` | TX Retry Rate 5GHz > 18% | `min_clients_snr_threshold` |
 
 ## Rate Limiting
 
 The agent implements token bucket rate limiting:
 - Default: 180 requests per 10 seconds
-- Automatically waits when limit is reached
+- Automatically waits when the limit is reached
 - Configurable via `rate_limit_requests` and `rate_limit_period`
 
 ## Logging
@@ -182,23 +183,23 @@ Logs include:
 - API errors and retries
 - Data delivery status
 
-Log level configurable via `agent.log_level`: DEBUG, INFO, WARN, ERROR
+Log level configurable via `agent.log_level`: `debug`, `info`, `warn`, `error`
 
 ## Troubleshooting
 
 ### Authentication Issues
-- Check credentials in config.yaml
+- Check credentials in `config.yaml`
 - Verify network connectivity to NetExperience API
 - Check logs for specific error messages
 
 ### No Metrics Collected
 - Ensure customers and equipment are cached (check logs)
 - Verify equipment has recent data in the API
-- Check time range calculation (fromTime/toTime)
+- Check time range calculation (`fromTime`/`toTime`)
 
-### RSSI / SNR / Critical RF metrics missing
+### Critical RF / SNR / TX Retry metrics missing
 - These are omitted when the AP client count is below the configured threshold
-- Check `min_clients_rssi_threshold` (controls RSSI % and Critical RF) and `min_clients_snr_threshold` (controls SNR, TX Retry Rate, and Critical RF)
+- Check `min_clients_rssi_threshold` (controls RSSI % and Critical RF metrics) and `min_clients_snr_threshold` (controls SNR, TX Retry Rate, and SNR/TxRetry-paired Critical RF indicators)
 - Default is 10 for both; APs with fewer clients will not emit these metrics
 
 ### Rate Limiting
@@ -218,7 +219,7 @@ Log level configurable via `agent.log_level`: DEBUG, INFO, WARN, ERROR
 
 Run locally with verbose logging:
 ```bash
-# Set log level to DEBUG in config.yaml
+# Set log_level: debug in configs/config.yaml
 ./netexperience-agent
 ```
 

--- a/netexperience-agent/configs/config.yaml.template
+++ b/netexperience-agent/configs/config.yaml.template
@@ -33,6 +33,7 @@ netexperience:
   
   # Metric thresholds
   min_clients_rssi_threshold: 10  # Minimum clients required for RSSI percentage calculations
+  min_clients_snr_threshold: 10  # Minimum clients required for SNR/retry rate calculations
 
 insightfinder:
   # InsightFinder Platform Configuration

--- a/netexperience-agent/configs/type.go
+++ b/netexperience-agent/configs/type.go
@@ -31,6 +31,7 @@ type NetExperienceConfig struct {
 	EquipmentCacheRefreshHours   int    `yaml:"equipment_cache_refresh_hours"`
 	EquipmentIPCacheRefreshHours int    `yaml:"equipment_ip_cache_refresh_hours"`
 	MinClientsRSSIThreshold      int    `yaml:"min_clients_rssi_threshold"`
+	MinClientsSNRThreshold       int    `yaml:"min_clients_snr_threshold"`
 }
 
 type InsightFinderConfig struct {

--- a/netexperience-agent/pkg/models/models.go
+++ b/netexperience-agent/pkg/models/models.go
@@ -65,15 +65,25 @@ type ServiceMetric struct {
 	ClientMacAddress *MacAddress `json:"clientMacAddress"`
 }
 
+// RadioStatistics represents per-radio statistics from the AP
+type RadioStatistics struct {
+	RxLastRssi             int   `json:"rxLastRssi"`
+	NumTxRetryAttemps      int   `json:"numTxRetryAttemps"`
+	NumTxFramesTransmitted int   `json:"numTxFramesTransmitted"`
+	SourceTimestampMs      int64 `json:"sourceTimestampMs"`
+}
+
 // ApNodeMetrics represents AP node metrics
 type ApNodeMetrics struct {
-	InventoryID                string                  `json:"inventoryId"`
-	PeriodLengthSec            int                     `json:"periodLengthSec"`
-	ClientMacAddressesPerRadio map[string][]MacAddress `json:"clientMacAddressesPerRadio"`
-	ChannelUtilizationPerRadio map[string]float64      `json:"channelUtilizationPerRadio"`
-	DataType                   string                  `json:"dataType"`
-	ClientCount                int                     `json:"clientCount,omitempty"`
-	SourceTimestampMs          int64                   `json:"sourceTimestampMs"`
+	InventoryID                string                     `json:"inventoryId"`
+	PeriodLengthSec            int                        `json:"periodLengthSec"`
+	ClientMacAddressesPerRadio map[string][]MacAddress    `json:"clientMacAddressesPerRadio"`
+	ChannelUtilizationPerRadio map[string]float64         `json:"channelUtilizationPerRadio"`
+	NoiseFloorPerRadio         map[string]float64         `json:"noiseFloorPerRadio"`
+	RadioStatsPerRadio         map[string]RadioStatistics `json:"radioStatsPerRadio"`
+	DataType                   string                     `json:"dataType"`
+	ClientCount                int                        `json:"clientCount,omitempty"`
+	SourceTimestampMs          int64                      `json:"sourceTimestampMs"`
 }
 
 // ClientMetrics represents client metrics
@@ -126,6 +136,13 @@ type EquipmentMetrics struct {
 
 	// WAN Port Speed
 	WANPortSpeed int
+
+	// 5GHz corroboration KPIs
+	SNR5GHz         float64 // rxLastRssi - noiseFloor (dB)
+	TxRetryRate5GHz float64 // numTxRetryAttemps / numTxFramesTransmitted (0–100%)
+
+	// Critical RF: 1 if ≥35% clients < -78 dBm AND any critical KPI breached, else 0
+	CriticalRF float64
 }
 
 // CachedData represents cached customer and equipment data

--- a/netexperience-agent/pkg/models/models.go
+++ b/netexperience-agent/pkg/models/models.go
@@ -141,8 +141,10 @@ type EquipmentMetrics struct {
 	SNR5GHz         float64 // rxLastRssi - noiseFloor (dB)
 	TxRetryRate5GHz float64 // numTxRetryAttemps / numTxFramesTransmitted (0–100%)
 
-	// Critical RF: 1 if ≥35% clients < -78 dBm AND any critical KPI breached, else 0
-	CriticalRF float64
+	// Critical RF indicators: each is 1 if ≥35% clients RSSI < -78 dBm AND the paired KPI is breached, else 0
+	CriticalRF_RSSI_SNR     float64 // RSSI condition AND SNR/SINR < 18 dB
+	CriticalRF_RSSI_Airtime float64 // RSSI condition AND Airtime Utilization > 85%
+	CriticalRF_RSSI_TxRetry float64 // RSSI condition AND TX Retry Rate > 18%
 }
 
 // CachedData represents cached customer and equipment data

--- a/netexperience-agent/worker/process.go
+++ b/netexperience-agent/worker/process.go
@@ -147,10 +147,35 @@ func (w *Worker) processEquipmentMetrics(equipment *models.Equipment, customer *
 		}
 
 		if len(rssiValues) > 0 {
-			threshold := w.config.NetExperience.MinClientsRSSIThreshold
+			rssiThreshold := w.config.NetExperience.MinClientsRSSIThreshold
 			result.AverageRSSI, result.ClientsRSSIBelow74, result.ClientsRSSIBelow78, result.ClientsRSSIBelow80,
 				result.PercentRSSIBelow74, result.PercentRSSIBelow78, result.PercentRSSIBelow80 =
-				models.CalculateRSSIMetrics(rssiValues, threshold)
+				models.CalculateRSSIMetrics(rssiValues, rssiThreshold)
+		}
+	}
+
+	// 5GHz corroboration KPIs — only computed when clients meet the SNR threshold
+	snrThreshold := w.config.NetExperience.MinClientsSNRThreshold
+	if result.TotalClients >= snrThreshold {
+		if stats5G, ok := apNodeMetrics.RadioStatsPerRadio["is5GHz"]; ok {
+			if noise5G, ok := apNodeMetrics.NoiseFloorPerRadio["is5GHz"]; ok {
+				result.SNR5GHz = float64(stats5G.RxLastRssi) - noise5G
+			}
+			if stats5G.NumTxFramesTransmitted > 0 {
+				result.TxRetryRate5GHz = float64(stats5G.NumTxRetryAttemps) / float64(stats5G.NumTxFramesTransmitted) * 100
+			}
+		}
+	}
+
+	// Critical RF: binary 1/0 — requires both thresholds to be met
+	rssiThreshold := w.config.NetExperience.MinClientsRSSIThreshold
+	if result.TotalClients >= rssiThreshold && result.TotalClients >= snrThreshold {
+		criticalRSSI := result.PercentRSSIBelow78 >= 35
+		criticalKPI := result.ChannelUtilization5GHz > 85 ||
+			(result.SNR5GHz > 0 && result.SNR5GHz < 18) ||
+			result.TxRetryRate5GHz > 18
+		if criticalRSSI && criticalKPI {
+			result.CriticalRF = 1
 		}
 	}
 
@@ -200,10 +225,23 @@ func (w *Worker) sendMetricBatch(timestamp int64, metrics []*models.EquipmentMet
 			"Channel Utilization 5GHz":   em.ChannelUtilization5GHz,
 			"Channel Utilization 2.4GHz": em.ChannelUtilization24GHz,
 			"Average RSSI":               em.AverageRSSI,
-			"% Clients RSSI < -74 dBm":   em.PercentRSSIBelow74,
-			"% Clients RSSI < -78 dBm":   em.PercentRSSIBelow78,
-			"% Clients RSSI < -80 dBm":   em.PercentRSSIBelow80,
 			"WAN Port Speed Mbps":        float64(em.WANPortSpeed),
+		}
+
+		if em.TotalClients >= w.config.NetExperience.MinClientsRSSIThreshold {
+			data["% Clients RSSI < -74 dBm"] = em.PercentRSSIBelow74
+			data["% Clients RSSI < -78 dBm"] = em.PercentRSSIBelow78
+			data["% Clients RSSI < -80 dBm"] = em.PercentRSSIBelow80
+		}
+
+		if em.TotalClients >= w.config.NetExperience.MinClientsSNRThreshold {
+			data["SNR 5GHz"] = em.SNR5GHz
+			data["TX Retry Rate 5GHz"] = em.TxRetryRate5GHz
+		}
+
+		if em.TotalClients >= w.config.NetExperience.MinClientsRSSIThreshold &&
+			em.TotalClients >= w.config.NetExperience.MinClientsSNRThreshold {
+			data["Critical RF"] = em.CriticalRF
 		}
 
 		metricData := models.MetricData{

--- a/netexperience-agent/worker/process.go
+++ b/netexperience-agent/worker/process.go
@@ -167,16 +167,20 @@ func (w *Worker) processEquipmentMetrics(equipment *models.Equipment, customer *
 		}
 	}
 
-	// Critical RF: binary 1/0 — requires both thresholds to be met
+	// Critical RF indicators — each requires RSSI threshold to be met and paired KPI to be breached
 	rssiThreshold := w.config.NetExperience.MinClientsRSSIThreshold
-	if result.TotalClients >= rssiThreshold && result.TotalClients >= snrThreshold {
-		criticalRSSI := result.PercentRSSIBelow78 >= 35
-		criticalKPI := result.ChannelUtilization5GHz > 85 ||
-			(result.SNR5GHz > 0 && result.SNR5GHz < 18) ||
-			result.TxRetryRate5GHz > 18
-		if criticalRSSI && criticalKPI {
-			result.CriticalRF = 1
+	criticalRSSI := result.TotalClients >= rssiThreshold && result.PercentRSSIBelow78 >= 35
+
+	if criticalRSSI && result.TotalClients >= snrThreshold {
+		if result.SNR5GHz > 0 && result.SNR5GHz < 18 {
+			result.CriticalRF_RSSI_SNR = 1
 		}
+		if result.TxRetryRate5GHz > 18 {
+			result.CriticalRF_RSSI_TxRetry = 1
+		}
+	}
+	if criticalRSSI && result.ChannelUtilization5GHz > 85 {
+		result.CriticalRF_RSSI_Airtime = 1
 	}
 
 	return result
@@ -239,9 +243,13 @@ func (w *Worker) sendMetricBatch(timestamp int64, metrics []*models.EquipmentMet
 			data["TX Retry Rate 5GHz"] = em.TxRetryRate5GHz
 		}
 
+		if em.TotalClients >= w.config.NetExperience.MinClientsRSSIThreshold {
+			data["≥ 35% of clients RSSI < -78 dBm AND Airtime Utilization > 85%"] = em.CriticalRF_RSSI_Airtime
+		}
 		if em.TotalClients >= w.config.NetExperience.MinClientsRSSIThreshold &&
 			em.TotalClients >= w.config.NetExperience.MinClientsSNRThreshold {
-			data["Critical RF"] = em.CriticalRF
+			data["≥ 35% of clients RSSI < -78 dBm AND SNR/SINR < 18 dB"] = em.CriticalRF_RSSI_SNR
+			data["≥ 35% of clients RSSI < -78 dBm AND TX Retry Rate > 18%"] = em.CriticalRF_RSSI_TxRetry
 		}
 
 		metricData := models.MetricData{

--- a/ruckus-agent/README.md
+++ b/ruckus-agent/README.md
@@ -1,94 +1,60 @@
-# Ruckus Agent Configuration Guide
+# Ruckus Agent
 
-## Overview
+Ruckus Agent is a Go-based data collection agent that fetches network performance metrics from a Ruckus SmartZone controller and sends them to InsightFinder for analysis and monitoring.
 
-The Ruckus Agent uses a YAML configuration file to connect to your Ruckus Wireless Controller and send metrics to InsightFinder. This guide explains how to configure the agent properly.
+## Features
 
-## Configuration File Location
+- **Concurrent Bulk Collection**: Fetches all AP and client data via paginated bulk queries with configurable concurrency
+- **Client Enrichment**: Enriches per-AP metrics with RSSI, SNR, and TX statistics derived from individual client data
+- **5GHz-only Critical Metrics**: Computes corroboration KPIs and critical alert indicators exclusively for 5GHz clients
+- **Metric Filtering**: Per-metric enable/disable flags to control exactly what is sent to InsightFinder
+- **Zone Mapping**: Optional JSON-based zone name remapping
+- **Streaming Processing**: Processes APs in configurable chunks to bound memory usage
 
-The configuration file should be placed at: `configs/config.yaml` (relative to the executable)
+## Architecture
 
-## Configuration Sections
+```
+ruckus-agent/
+├── configs/          # Configuration types and YAML loading
+├── insightfinder/    # InsightFinder API client
+├── pkg/models/       # Data models, metric conversion, utilities
+│   ├── models.go     # APDetail, ClientInfo, MetricData, ToMetricData
+│   └── utils.go      # Device name cleaning, zone mapping, POE parsing
+├── ruckus/           # Ruckus SmartZone API client
+│   ├── ruckus.go     # Authentication and HTTP client
+│   ├── streaming.go  # Bulk AP pagination and streaming
+│   ├── client_data.go # Client enrichment, 5GHz KPIs, alert indicators
+│   ├── get_bulk_ap_data.go
+│   └── type.go       # Request/response types
+├── worker/           # Collection orchestration
+│   ├── worker.go     # Lifecycle, scheduling, streaming loop
+│   └── v1_send_data.go
+└── main.go           # Entry point
+```
 
-### ruckus - Ruckus Controller Settings
+## Configuration
 
-Configure connection to your Ruckus Wireless Controller:
-
-| Parameter | Required | Default | Description |
-|-----------|----------|---------|-------------|
-| `controller_host` | Yes | - | IP address or hostname of Ruckus controller |
-| `controller_port` | No | 8443 | HTTPS port for Ruckus controller API |
-| `username` | Yes | - | Username for Ruckus controller authentication |
-| `password` | Yes | - | Password for Ruckus controller authentication |
-| `api_version` | No | v10_0 | Ruckus API version (v10_0, v11_0, v11_1, etc.) |
-| `verify_ssl` | No | false | Enable/disable SSL certificate verification |
-| `max_concurrent_requests` | No | 10 | Maximum concurrent API requests |
-
-### insightfinder - InsightFinder Settings
-
-Configure connection to InsightFinder platform:
-
-| Parameter | Required | Default | Description |
-|-----------|----------|---------|-------------|
-| `server_url` | Yes | - | InsightFinder server URL (e.g., https://app.insightfinder.com) |
-| `username` | Yes | - | InsightFinder username |
-| `license_key` | Yes | - | InsightFinder license key |
-| `project_name` | Yes | - | InsightFinder project name |
-| `system_name` | No | project_name | System name for grouping |
-| `project_type` | No | Metric | Project type (Metric, Log, Trace, etc.) |
-| `cloud_type` | No | OnPremise | Cloud type (OnPremise, AWS, Azure, GCP) |
-| `instance_type` | No | OnPremise | Instance type |
-| `is_container` | No | false | Set to true if running in container |
-| `sampling_interval` | No | 300 | Data collection interval in seconds |
-
-### agent - Agent Settings
-
-Configure agent behavior:
-
-| Parameter | Required | Default | Description |
-|-----------|----------|---------|-------------|
-| `log_level` | No | info | Logging level (debug, info, warn, error) |
-| `data_format` | No | JSON | Data format (for future use) |
-| `timezone` | No | UTC | Timezone for timestamps |
-| `filters_include` | No | - | Comma-separated list of AP filters to include |
-| `filters_exclude` | No | - | Comma-separated list of AP filters to exclude |
-
-### state - State Management
-
-Internal state tracking (automatically managed):
-
-| Parameter | Description |
-|-----------|-------------|
-| `last_collection_timestamp` | Last successful data collection timestamp |
-
-## Sample Configuration File
-
-Create a file named `config.yaml` in the `configs/` directory:
+Edit `configs/config.yaml`:
 
 ```yaml
-# Ruckus Agent Configuration File
-# Place this file at: configs/config.yaml
-
 agent:
-  # Agent behavior settings
-  log_level: info
+  log_level: info        # debug | info | warn | error
   data_format: JSON
   timezone: UTC
-  filters_include: ""
-  filters_exclude: ""
+  filters_include: ""    # Comma-separated AP name substrings to include
+  filters_exclude: ""    # Comma-separated AP name substrings to exclude
 
 ruckus:
-  # Ruckus Wireless Controller Configuration
   controller_host: 192.168.1.100
   controller_port: 8443
   username: your_ruckus_username
   password: your_ruckus_password
-  api_version: v11_1
+  api_version: v11_1     # v10_0 for SZ 5.x, v11_0/v11_1 for SZ 6.x
   verify_ssl: false
-  max_concurrent_requests: 10
+  max_concurrent_requests: 20
+  send_component_name_as_AP: true
 
 insightfinder:
-  # InsightFinder Platform Configuration
   server_url: https://app.insightfinder.com
   username: your_if_username
   license_key: your_license_key_here
@@ -98,71 +64,137 @@ insightfinder:
   cloud_type: OnPremise
   instance_type: OnPremise
   is_container: false
-  sampling_interval: 300
+  sampling_interval: 300   # seconds; 300 = 5-minute window
 
-state:
-  # Internal state (automatically managed)
-  last_collection_timestamp: 0
+threshold:
+  # Minimum number of 5GHz clients required before computing 5GHz KPIs
+  # and critical alert indicators for an AP. APs below this count are skipped.
+  min_clients_rssi_threshold: 10
+  min_clients_snr_threshold: 10
+
+metric_filter:
+  # Set true to stream a metric to InsightFinder, false to suppress it.
+  num_clients_total: false
+  num_clients_24g: false
+  num_clients_5g: false
+  num_clients_6g: false
+
+  airtime_24g: false
+  airtime_5g: false
+  airtime_6g: false
+  airtime_24g_clients_over_35: true
+  airtime_5g_clients_over_35: true
+  airtime_6g_clients_over_35: true
+
+  rssi_avg: false
+  snr_avg: false
+  clients_rssi_below_74: false
+  clients_rssi_below_78: false
+  clients_rssi_below_80: false
+  clients_snr_below_15: false
+  clients_snr_below_18: false
+  clients_snr_below_20: false
+
+  ethernet_status_mbps: true
 ```
 
-## Configuration Steps
-
-### Step 1: Create Configuration Directory
+## Installation
 
 ```bash
-mkdir -p configs
+go mod download
+go build -o ruckus-agent
 ```
 
-### Step 2: Create Configuration File
-
-Copy the sample configuration above to `configs/config.yaml` and modify the values:
+## Running
 
 ```bash
-cp configs/config.yaml.example configs/config.yaml
-nano configs/config.yaml
+./ruckus-agent
 ```
 
-### Step 3: Configure Ruckus Controller
+## Metrics Collected
 
-1. **Controller Host**: Enter your Ruckus controller's IP address or hostname
-2. **Credentials**: Use an admin or read-only user account
-3. **API Version**: Check your controller's firmware version:
-   - SmartZone 5.x: use `v10_0`
-   - SmartZone 6.x: use `v11_0` or `v11_1`
-4. **SSL**: Set `verify_ssl: false` for self-signed certificates
+### Standard AP Metrics (filter-gated)
 
-### Step 4: Configure InsightFinder
+These are enabled/disabled individually via `metric_filter` in `config.yaml`:
 
-1. **Server URL**: Your InsightFinder server URL
-2. **Credentials**: Get from your InsightFinder account settings
-3. **Project Name**: Choose a descriptive name (will be created automatically)
-4. **Sampling Interval**: Recommended 300 seconds (5 minutes) for WiFi metrics
+| Metric | Description |
+|--------|-------------|
+| `Num Clients Total` | Total associated clients |
+| `Num Clients 24G` | Clients on 2.4GHz |
+| `Num Clients 5G` | Clients on 5GHz |
+| `Num Clients 6G` | Clients on 6GHz |
+| `Airtime 24G Percent` | 2.4GHz channel utilization % |
+| `Airtime 5G Percent` | 5GHz channel utilization % |
+| `Airtime 6G Percent` | 6GHz channel utilization % |
+| `Airtime 24G Clients > 35` | 2.4GHz airtime % (only if >35 clients, else 0) |
+| `Airtime 5G Clients > 35` | 5GHz airtime % (only if >35 clients, else 0) |
+| `Airtime 6G Clients > 35` | 6GHz airtime % (only if >35 clients, else 0) |
+| `RSSI Avg` | Average RSSI across all clients (positive dBm) |
+| `SNR Avg` | Average SNR across all clients (dB) |
+| `% Clients RSSI < -74 dBm` | % clients in orange signal zone |
+| `% Clients RSSI < -78 dBm` | % clients in red signal zone |
+| `% Clients RSSI < -80 dBm` | % clients below red signal zone |
+| `% Clients SNR < 15 dBm` | % clients below SNR 15 dB |
+| `% Clients SNR < 18 dBm` | % clients below SNR 18 dB |
+| `% Clients SNR < 20 dBm` | % clients below SNR 20 dB |
+| `Ethernet Status Mbps` | WAN/uplink port speed parsed from POE port status |
 
-## Configuration Validation
+### 5GHz Corroboration KPIs
 
-The agent validates your configuration on startup and will report errors for:
+Always sent when the AP has ≥ `min_clients_rssi_threshold` 5GHz clients. Computed as **p50 (median) across all 5GHz clients** for the current collection window.
 
-- Missing required fields
-- Invalid URLs or hostnames  
-- Unreachable controllers or InsightFinder servers
-- Invalid credentials
-- Network connectivity issues
+5GHz clients are identified by `radioType` starting with `"a/"` (e.g. `a/n/ac`, `a/n/ac/ax`, `a/n`).
 
-### Debug Mode
+| Metric | Description |
+|--------|-------------|
+| `Median SNR 5GHz` | p50 SNR across 5GHz clients (dB) |
+| `TX Retry Rate 5GHz` | p50 TX retry rate across 5GHz clients: `txDropDataFrames / txFrames × 100` (%) |
 
-Enable debug logging for detailed troubleshooting:
+### Critical Alert Indicators (5GHz only)
 
-```yaml
-agent:
-  log_level: debug
-```
+Binary `1`/`0` metrics. Each fires independently when its specific pair of conditions is simultaneously true. Requires ≥ `min_clients_rssi_threshold` 5GHz clients per AP.
 
-This will provide detailed API requests, responses, and internal processing information.
+The RSSI condition shared by all critical indicators: **≥ 35% of 5GHz clients have RSSI < −78 dBm**.
 
-## YAML Configuration Notes
+| Metric sent to InsightFinder | Paired KPI condition |
+|------------------------------|----------------------|
+| `≥ 35% of clients RSSI < -78 dBm AND SNR/SINR < 18 dB` | Median SNR 5GHz < 18 dB |
+| `≥ 35% of clients RSSI < -78 dBm AND TX Retry Rate > 18%` | Median TX Retry Rate 5GHz > 18% |
+| `≥ 35% of clients RSSI < -78 dBm AND Airtime Utilization > 85%` | Airtime 5GHz > 85% |
+| `≥ 35% of clients RSSI < -78 dBm AND Median MCS < 3` | Median TX MCS Rate 5GHz < 26,000 kbps (≈ MCS 3) |
 
-- Use spaces (not tabs) for indentation
-- Boolean values should be lowercase: `true`, `false`
-- Strings with special characters should be quoted
-- Empty values can be represented as empty strings `""` or omitted entirely
-- Comments start with `#` and can be placed on their own line or at the end of a line
+**MCS threshold note**: The Ruckus API reports `medianTxMCSRate` in kbps. Based on 802.11n 20 MHz 1SS rates, MCS 3 = 26,000 kbps and MCS 7 = 65,000 kbps. The indicator uses `< 26,000 kbps` as the critical threshold.
+
+## Troubleshooting
+
+### No 5GHz KPI or Critical Indicator metrics appearing
+- Check that the AP has ≥ `min_clients_rssi_threshold` 5GHz clients (`radioType` starting with `a/`)
+- Enable `debug` log level to see per-AP client counts
+- Verify client data is being fetched (look for "Client data collection complete" in logs)
+
+### Standard metrics not appearing
+- Confirm the relevant flag is `true` in `metric_filter` section of `config.yaml`
+
+### Authentication failures
+- Verify `controller_host`, `username`, and `password`
+- Set `verify_ssl: false` for controllers with self-signed certificates
+- Check `api_version` matches your SmartZone firmware:
+  - SmartZone 5.x → `v10_0`
+  - SmartZone 6.x → `v11_0` or `v11_1`
+
+### High memory usage
+- Reduce `max_concurrent_requests` to lower peak concurrency
+- The worker streams APs in chunks; chunk size is set internally to 1000 APs
+
+## Development
+
+### Adding New Metrics
+
+1. Add field to `APDetail` in `pkg/models/models.go`
+2. Populate it in `ruckus/client_data.go:EnrichAPDataWithClientMetrics()` or `enrich5GHzMetrics()`
+3. Send it in `pkg/models/models.go:ToMetricData()`
+4. If filter-gated, add a flag to `MetricFilterConfig` in `configs/type.go` and implement the interface method
+
+## License
+
+Copyright InsightFinder Inc.

--- a/ruckus-agent/pkg/models/models.go
+++ b/ruckus-agent/pkg/models/models.go
@@ -42,10 +42,14 @@ type ClientResponse struct {
 }
 
 type ClientInfo struct {
-	APMac     string `json:"apMac"`
-	ClientMac string `json:"clientMac"`
-	RSSI      int    `json:"rssi"`
-	SNR       int    `json:"snr"`
+	APMac            string `json:"apMac"`
+	ClientMac        string `json:"clientMac"`
+	RSSI             int    `json:"rssi"`
+	SNR              int    `json:"snr"`
+	RadioType        string `json:"radioType"`
+	TxFrames         int    `json:"txFrames"`
+	TxDropDataFrames int    `json:"txDropDataFrames"`
+	MedianTxMCSRate  int    `json:"medianTxMCSRate"` // kbps; MCS 3 = 26000, MCS 7 = 65000
 }
 
 type APInfo struct {
@@ -98,6 +102,16 @@ type APDetail struct {
 	SNRPercentBelow15  *float64 `json:"snrPercentBelow15,omitempty"`  // Percentage of clients < -15 dBm
 	SNRPercentBelow18  *float64 `json:"snrPercentBelow18,omitempty"`  // Percentage of clients < -18 dBm
 	SNRPercentBelow20  *float64 `json:"snrPercentBelow20,omitempty"`  // Percentage of clients < -20 dBm
+
+	// 5GHz-only corroboration KPIs (p50 across 5GHz clients, requires ≥MinClientsThreshold 5GHz clients)
+	MedianSNR5GHz   *float64 `json:"medianSNR5GHz,omitempty"`
+	TxRetryRate5GHz *float64 `json:"txRetryRate5GHz,omitempty"` // percent
+
+	// Critical alert indicators (binary 0/1), 5GHz clients only
+	AlertCrit_RSSI_SNR     *float64 `json:"alertCrit_RSSI_SNR,omitempty"`
+	AlertCrit_RSSI_TxRetry *float64 `json:"alertCrit_RSSI_TxRetry,omitempty"`
+	AlertCrit_RSSI_Airtime *float64 `json:"alertCrit_RSSI_Airtime,omitempty"`
+	AlertCrit_RSSI_MCS     *float64 `json:"alertCrit_RSSI_MCS,omitempty"`
 }
 
 // InsightFinder data structure
@@ -210,6 +224,28 @@ func (ap *APDetail) ToMetricData(componentNameAsAP bool, filter MetricFilter) *M
 		if mbpsValue := ExtractMbpsFromPOEPortStatus(ap.POEPortStatus); mbpsValue != nil {
 			metric.Data["Ethernet Status Mbps"] = *mbpsValue
 		}
+	}
+
+	// 5GHz-only corroboration KPIs
+	if ap.MedianSNR5GHz != nil {
+		metric.Data["Median SNR 5GHz"] = *ap.MedianSNR5GHz
+	}
+	if ap.TxRetryRate5GHz != nil {
+		metric.Data["TX Retry Rate 5GHz"] = *ap.TxRetryRate5GHz
+	}
+
+	// Critical alert indicators
+	if ap.AlertCrit_RSSI_SNR != nil {
+		metric.Data["≥ 35% of clients RSSI < -78 dBm AND SNR/SINR < 18 dB"] = *ap.AlertCrit_RSSI_SNR
+	}
+	if ap.AlertCrit_RSSI_TxRetry != nil {
+		metric.Data["≥ 35% of clients RSSI < -78 dBm AND TX Retry Rate > 18%"] = *ap.AlertCrit_RSSI_TxRetry
+	}
+	if ap.AlertCrit_RSSI_Airtime != nil {
+		metric.Data["≥ 35% of clients RSSI < -78 dBm AND Airtime Utilization > 85%"] = *ap.AlertCrit_RSSI_Airtime
+	}
+	if ap.AlertCrit_RSSI_MCS != nil {
+		metric.Data["≥ 35% of clients RSSI < -78 dBm AND Median MCS < 3"] = *ap.AlertCrit_RSSI_MCS
 	}
 
 	return metric

--- a/ruckus-agent/ruckus/client_data.go
+++ b/ruckus-agent/ruckus/client_data.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/insightfinder/ruckus-agent/pkg/models"
@@ -338,8 +340,100 @@ func EnrichAPDataWithClientMetrics(apDetails []models.APDetail, clientMap map[st
 			enriched[i].SNRPercentBelow15 = &snrBelow15
 			enriched[i].SNRPercentBelow18 = &snrBelow18
 			enriched[i].SNRPercentBelow20 = &snrBelow20
+
+			// 5GHz-only corroboration KPIs and alert indicators
+			enrich5GHzMetrics(&enriched[i], clients, rssiThreshold)
 		}
 	}
 
 	return enriched
+}
+
+// enrich5GHzMetrics computes 5GHz-only KPIs and alert indicators for a single AP.
+// Requires at least rssiThreshold 5GHz clients; otherwise nothing is set.
+func enrich5GHzMetrics(ap *models.APDetail, clients []models.ClientInfo, minClients int) {
+	var clients5G []models.ClientInfo
+	for _, c := range clients {
+		if is5GHzClient(c.RadioType) {
+			clients5G = append(clients5G, c)
+		}
+	}
+	if len(clients5G) < minClients {
+		return
+	}
+
+	// --- Corroboration KPIs (p50) ---
+
+	snrVals := make([]float64, 0, len(clients5G))
+	retryRates := make([]float64, 0, len(clients5G))
+	mcsVals := make([]float64, 0, len(clients5G))
+
+	var rssiBelow78 int
+	for _, c := range clients5G {
+		snrVals = append(snrVals, float64(c.SNR))
+		if c.TxFrames > 0 {
+			retryRates = append(retryRates, float64(c.TxDropDataFrames)/float64(c.TxFrames)*100)
+		}
+		if c.MedianTxMCSRate > 0 {
+			mcsVals = append(mcsVals, float64(c.MedianTxMCSRate))
+		}
+		if c.RSSI < -78 {
+			rssiBelow78++
+		}
+	}
+
+	medSNR := medianFloat64(snrVals)
+	ap.MedianSNR5GHz = &medSNR
+
+	medRetry := 0.0
+	if len(retryRates) > 0 {
+		medRetry = medianFloat64(retryRates)
+	}
+	ap.TxRetryRate5GHz = &medRetry
+
+	// --- Critical alert indicators: ≥35% of 5GHz clients RSSI < -78 dBm AND KPI breached ---
+
+	pct78 := float64(rssiBelow78) / float64(len(clients5G)) * 100
+	crit35 := pct78 >= 35
+
+	medMCS := medianFloat64(mcsVals) // kbps; MCS 3 = 26000
+
+	critSNR := binaryIndicator(crit35 && medSNR < 18)
+	critRetry := binaryIndicator(crit35 && medRetry > 18)
+	critAirtime := binaryIndicator(crit35 && ap.Airtime5G > 85)
+	critMCS := binaryIndicator(crit35 && medMCS > 0 && medMCS < 26000)
+	ap.AlertCrit_RSSI_SNR = &critSNR
+	ap.AlertCrit_RSSI_TxRetry = &critRetry
+	ap.AlertCrit_RSSI_Airtime = &critAirtime
+	ap.AlertCrit_RSSI_MCS = &critMCS
+}
+
+// is5GHzClient returns true when the client's radioType indicates 5 GHz band.
+// 5 GHz types in Ruckus API start with "a/" (e.g. "a/n/ac", "a/n/ac/ax", "a/n").
+func is5GHzClient(radioType string) bool {
+	lower := strings.ToLower(radioType)
+	return strings.HasPrefix(lower, "a/") || lower == "a"
+}
+
+// medianFloat64 returns the p50 of a float64 slice (sorts a copy).
+func medianFloat64(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := make([]float64, len(values))
+	copy(sorted, values)
+	sort.Float64s(sorted)
+	n := len(sorted)
+	if n%2 == 0 {
+		return (sorted[n/2-1] + sorted[n/2]) / 2
+	}
+	return sorted[n/2]
+}
+
+// binaryIndicator converts a boolean condition to 1.0 or 0.0.
+func binaryIndicator(condition bool) float64 {
+	if condition {
+		return 1
+	}
+	return 0
 }


### PR DESCRIPTION
https://insightfinders.atlassian.net/browse/II-23329