### PR TITLE
II-24680 Update accessparks device metadata

### DIFF
--- a/accessparks-device-metadata/README.md
+++ b/accessparks-device-metadata/README.md
@@ -12,11 +12,59 @@ found (or not) in each place:
 
 ```json
 {
-  "controller": {"name": "UniFi", "device_name": "LRF-Clubhouse-AP", "ip": "10.194.153.12", "mac": "0c:ea:14:4f:61:e1"},
-  "jira":       {"id": "IHS-68691", "ip": "10.194.153.12", "mac": "0C:EA:14:4F:61:E1"},
-  "zabbix":     {"id": "44598"}
+  "controller": {"name": "UniFi", "device_name": "LRF-Clubhouse-AP", "ip": "10.194.153.12", "mac": "0C:EA:14:4F:61:E1", "serial": "F4E2C6A1B3D9"},
+  "jira":       {"id": "IHS-68691", "device_name": "LRF-Clubhouse-AP", "ip": "10.194.153.12", "mac": "0C:EA:14:4F:61:E1", "zabbix_host_id": "44598", "match_method": "controller.mac"},
+  "zabbix":     {"id": "44598", "device_name": "LRF-Clubhouse-AP", "match_method": "jira.id"}
 }
 ```
+
+Every key is always present. A device that isn't in Jira or Zabbix — or one
+whose controller doesn't report an IP or MAC — gets `""` rather than a
+dropped key, so "missing from Jira" stays queryable and alertable in
+InsightFinder instead of vanishing from the record.
+
+`match_method` names **the field of this record whose value was used as the
+lookup key**, so you can see exactly what was matched on instead of
+inferring it. Identifiers are tried strongest-first and the first hit wins:
+
+| `jira.match_method` | Looked up | Matched against |
+| --- | --- | --- |
+| `controller.mac` | the controller's MAC | Jira `mac_address` |
+| `controller.serial` | the controller's serial | Jira `serial_number` |
+| `controller.device_name` | the controller's device name | Jira `name` |
+
+| `zabbix.match_method` | Looked up | Matched against |
+| --- | --- | --- |
+| `jira.id` | the Jira device key, e.g. `IHS-68691` | the Zabbix host tag `jira_device_key` |
+| `jira.zabbix_host_id` | the hostid Jira records | that Zabbix `hostid`, if it still exists |
+| `controller.device_name` | the controller's device name | Zabbix host / visible name |
+| `controller.ip` | the controller's IP | Zabbix primary-interface IP |
+
+Note the two Zabbix fallbacks key off the **controller**, not Jira — only
+the first two tiers use anything Jira supplied. Every field a `match_method`
+can name is present in the record, which is why `controller.serial` and
+`jira.zabbix_host_id` are emitted even though nothing else reads them.
+
+Jira matching is whitespace-insensitive: a Jira label is tried exactly
+(case-insensitively) first, then with all whitespace stripped, so the
+controller's `DKOA-DC723-RN` matches Jira's `DKOA-DC 723-RN` and a
+controller name with a stray leading space still matches. See
+`src/jira_assets.py` for why that requires matching locally against
+`GET /devices/export` rather than per-device registry lookups.
+
+Whitespace is ignored when *finding* and *comparing* devices, not when
+reporting them: every value in the record is shipped exactly as its source
+holds it, whitespace included, so the record stays a faithful picture of
+what each system actually contains. InsightFinder's ingestion rules
+constrain the **instance name**, not the log payload — that's handled by
+`sanitize_instance_name` (no space, `,`, `_`, `@`, `#`, `:`), which is the
+only place a value is rewritten to satisfy them.
+
+The `ip≠`/`mac≠` flags likewise compare whitespace-insensitively, so a
+device matched despite stray spacing isn't then reported as disagreeing with
+itself — Jira holds MACs recorded as `" 48:A9:8A:9B:EA:C9"` and
+`"48:A9:8A:B6: E7:8A"`, which are the same addresses their controllers
+report, not different ones.
 
 This is a cron job, not a daemon — one pass per invocation, no internal loop.
 
@@ -86,11 +134,12 @@ python main.py --limit 10                        # cap devices per controller (q
 `--table` output, e.g.:
 
 ```
-CONTROLLER  DEVICE            CTRL IP        CTRL MAC           JIRA KEY   JIRA IP        JIRA MAC           ZBX ID  STATUS
-UniFi       LRF-Clubhouse-AP  10.194.153.12  0c:ea:14:4f:61:e1  IHS-68691  10.194.153.12  0C:EA:14:4F:61:E1  44598   ok
-UniFi       U6+               10.194.192.20  0c:ea:14:e3:d5:05  -          -              -                  -       no-jira, no-zabbix
+CONTROLLER  DEVICE             CTRL IP        CTRL MAC           JIRA KEY   JIRA NAME          JIRA IP        JIRA MAC           JIRA VIA       ZBX ID  ZBX NAME           ZBX VIA          STATUS
+UniFi       LRF-Clubhouse-AP   10.194.153.12  0C:EA:14:4F:61:E1  IHS-68691  LRF-Clubhouse-AP   10.194.153.12  0C:EA:14:4F:61:E1  MAC address    44598   LRF-Clubhouse-AP   Jira device key  ok
+Tarana      DKOA-DC723-RN      172.27.68.142  04:F1:7D:06:11:34  IHS-67507  DKOA-DC 723-RN     10.195.96.129 ≠                   Device name    43171   DKOA-DC 723-RN     Jira device key  ip≠
+UniFi       U6+                10.194.192.20  0C:EA:14:E3:D5:05  -          -                  -              -                  -              -       -                  -                no-jira, no-zabbix
 
-33 devices | jira: 19 matched, 14 missing | zabbix: 19 matched, 14 missing | ip mismatch: 1 | mac mismatch: 0
+8410 devices | jira: 7288 matched, 1122 missing | zabbix: 7697 matched, 713 missing | ip mismatch: 449 | mac mismatch: 864
 ```
 
 The summary line prints on every run — it's the actual deliverable. With
@@ -151,10 +200,20 @@ raw `nohup`.
   and Positron over the same connection (`POSITRON_TUNNEL_*`) — no separate
   script needed for Positron.
 - **A partial picture is never silently published as "device is missing."**
-  If every controller returns zero devices, the whole run aborts. A Zabbix
-  login/`host.get` failure aborts the run. A device whose Jira lookup
-  *errors* (as opposed to a confirmed 404) is excluded from the batch and
-  counted separately — never reported as missing.
+  If every controller returns zero devices, the whole run aborts. So does a
+  Zabbix login/`host.get` failure, or a failed Jira Assets
+  `GET /devices/export` — a network problem is never shipped to
+  InsightFinder as a fleet-wide Jira or Zabbix gap. A device whose live
+  Zabbix tag lookup errors is reported as unresolved and counted separately,
+  never as missing.
+- **An ambiguous identifier is refused, not guessed.** Jira has MACs and
+  serials that appear on more than one device (placeholders like `-` and
+  `n/a`, but also real duplicates left behind by device replacements). Such
+  a value can't identify either device, so it's disabled as a match key and
+  matching falls through to the next identifier — which is how
+  `LKLV-Cabin11-GN` now matches its own asset instead of the `-GAM` sharing
+  its MAC. The run logs how many devices hit one, so the Jira data can be
+  cleaned up.
 - **UniFi** — the Site Manager API key must be a console-owner key; a
   restricted/invited key gets `403 insufficient permissions` on the Cloud
   Connector proxy paths.
@@ -164,14 +223,16 @@ raw `nohup`.
   login degrades to "skipped" in the run summary, never an aborted run.
 - **Telrad** — implements **CPEs only**, over SSH to the BreezeVIEW CLI
   (port 9383 — a different service from the REST NBI's port 9382 on the same
-  host); requires `sshpass`. Only `online` CPEs appear in a snapshot; neither
-  Telrad CPEs nor Tarana devices expose a MAC address.
+  host); requires `sshpass`. Only `online` CPEs appear in a snapshot, and
+  Telrad CPEs do not expose a MAC address.
 - **Baicells** — rate-limited to 20 requests/min account-wide; IP requires a
   per-device call cached to `.cache/baicells_ips.json` and capped per run by
   `BAICELLS_ENRICH_BUDGET_SECONDS` — a large fleet fills in IPs over several
   runs, so `ip=""` on a given run is expected, not an error.
 - **Tarana** — `TARANA_REGION_IDS` is pinned to `33,1203,1202`; leaving it
-  blank falls back to runtime discovery, which is known to miss regions.
+  blank falls back to runtime discovery, which is known to miss regions. The
+  device-search response carries `macAddress` even though `tarana-agent`'s
+  Go `Device` struct omits it, so Tarana devices do reconcile by MAC.
 - **NetExperience** — `NETEXPERIENCE_BASE_URL` is the tenant API host, *not*
   `www.netexperience.com`.
 - **Positron** — reached through the same SSH tunnel as Zabbix. Lists two
@@ -204,7 +265,7 @@ failing the run.
 | UniFi | `/v1/sites` (traversal only) → `/v1/connector/consoles/{hostId}/proxy/network/api/s/{slug}/stat/device` | `name` | `ip` | `mac` | `serial` |
 | UISP | `/nms/api/v2.1/devices` | `identification.name` | `ipAddress` (strip `/cidr`) | `identification.mac` | `identification.serialNumber` |
 | Mimosa | `/{network_id}/devices/?pageNumber&pageSize` | `friendlyName` | `ipAddress` | `macAddress` | `serialNumber` |
-| Tarana | `/api/nqs/v1/regions/devices/search` | `hostName` | `ip` | — | `serialNumber` |
+| Tarana | `/api/nqs/v1/regions/devices/search` | `hostName` | `ip` | `macAddress` | `serialNumber` |
 | Baicells | `/device/group` → `/device/query` per group → `/cpe/infos/{serial}` for ip | `host_name` | `ipAddress` (per-device call) | `mac_address` | `serial_number` |
 | NetExperience | `/portal/cmap/customer/forSp` → `/portal/equipment/forCustomer` → `/portal/status/forEquipment` for ip | `name` | `details.reportedIpV4Addr` (3rd call) | `baseMacAddress.addressAsString` | `serial` |
 | Cambium | `{base}/tree/devices` | `cfg.name` → `name` | `net.wan` → `net.ip` | `mac` | `sn` |

--- a/accessparks-device-metadata/main.py
+++ b/accessparks-device-metadata/main.py
@@ -41,19 +41,23 @@ from controllers import build_controllers
 from insightfinder import Config as IFConfig
 from insightfinder import InsightFinder
 from jira_assets import JiraAssetClient
+from jira_assets import build_index as build_jira_index
 from models import ReconciledDevice
 from reconcile import build_instance_tags
 from reconcile import build_log_data
+from reconcile import ip_mismatch
+from reconcile import mac_mismatch
 from reconcile import reconcile_device
 from zabbix import build_index as build_zabbix_index
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 logger = logging.getLogger(__name__)
 
-# Each device does up to 3 sequential Jira Asset Registry lookups plus a live
-# Zabbix tag RPC — at fleet scale (thousands of devices) that's minutes of
-# per-device network latency. Bounded concurrency here matches the pattern
-# already used for NetExperience/Baicells per-device network loops.
+# Jira matching is a local dict lookup (see jira_assets.py), but each device
+# still costs a live Zabbix tag RPC — at fleet scale (thousands of devices)
+# that's minutes of per-device network latency. Bounded concurrency here
+# matches the pattern already used for NetExperience/Baicells per-device
+# network loops.
 RECONCILE_CONCURRENCY = 20
 
 
@@ -77,7 +81,21 @@ def parse_args() -> argparse.Namespace:
 
 
 def print_table(rows: list[ReconciledDevice]) -> None:
-    headers = ["CONTROLLER", "DEVICE", "CTRL IP", "CTRL MAC", "JIRA KEY", "JIRA IP", "JIRA MAC", "ZBX ID", "STATUS"]
+    headers = [
+        "CONTROLLER",
+        "DEVICE",
+        "CTRL IP",
+        "CTRL MAC",
+        "JIRA KEY",
+        "JIRA NAME",
+        "JIRA IP",
+        "JIRA MAC",
+        "JIRA VIA",
+        "ZBX ID",
+        "ZBX NAME",
+        "ZBX VIA",
+        "STATUS",
+    ]
     table: list[list[str]] = []
     for r in rows:
         d = r.controller_device
@@ -85,9 +103,7 @@ def print_table(rows: list[ReconciledDevice]) -> None:
         zabbix = r.zabbix
 
         status_parts = []
-        if r.jira_error:
-            status_parts.append("jira-error")
-        elif jira is None:
+        if jira is None:
             status_parts.append("no-jira")
         if r.zabbix_error:
             status_parts.append("zabbix-error")
@@ -96,10 +112,10 @@ def print_table(rows: list[ReconciledDevice]) -> None:
 
         jira_ip = jira.ip if jira else "-"
         jira_mac = jira.mac if jira else "-"
-        if jira and jira.ip and d.ip and jira.ip != d.ip:
+        if ip_mismatch(r):
             jira_ip += " ≠"
             status_parts.append("ip≠")
-        if jira and jira.mac and d.mac and jira.mac.lower() != d.mac.lower():
+        if mac_mismatch(r):
             jira_mac += " ≠"
             status_parts.append("mac≠")
 
@@ -110,9 +126,13 @@ def print_table(rows: list[ReconciledDevice]) -> None:
                 d.ip or "-",
                 d.mac or "-",
                 jira.object_key if jira else "-",
+                (jira.device_name if jira else "") or "-",
                 jira_ip,
                 jira_mac,
+                (jira.match_method if jira else "") or "-",
                 zabbix.hostid if zabbix else "-",
+                (zabbix.device_name if zabbix else "") or "-",
+                (zabbix.match_method if zabbix else "") or "-",
                 ", ".join(status_parts) or "ok",
             ]
         )
@@ -123,24 +143,19 @@ def print_table(rows: list[ReconciledDevice]) -> None:
         print("  ".join(c.ljust(w) for c, w in zip(row, widths)))
 
 
-def build_summary(rows: list[ReconciledDevice], jira_errors: int, zabbix_errors: int = 0) -> str:
+def build_summary(rows: list[ReconciledDevice], zabbix_errors: int = 0) -> str:
     total = len(rows)
     jira_matched = sum(1 for r in rows if r.jira)
-    jira_missing = sum(1 for r in rows if r.jira is None and not r.jira_error)
+    jira_missing = sum(1 for r in rows if r.jira is None)
     zabbix_matched = sum(1 for r in rows if r.zabbix)
     zabbix_missing = sum(1 for r in rows if r.zabbix is None and not r.zabbix_error)
-    ip_mismatch = sum(1 for r in rows if r.jira and r.jira.ip and r.controller_device.ip and r.jira.ip != r.controller_device.ip)
-    mac_mismatch = sum(
-        1
-        for r in rows
-        if r.jira and r.jira.mac and r.controller_device.mac and r.jira.mac.lower() != r.controller_device.mac.lower()
-    )
-    extra = f" | jira lookup errors (excluded): {jira_errors}" if jira_errors else ""
-    extra += f" | zabbix lookup errors (unresolved): {zabbix_errors}" if zabbix_errors else ""
+    ip_mismatches = sum(1 for r in rows if ip_mismatch(r))
+    mac_mismatches = sum(1 for r in rows if mac_mismatch(r))
+    extra = f" | zabbix lookup errors (unresolved): {zabbix_errors}" if zabbix_errors else ""
     return (
         f"{total} devices | jira: {jira_matched} matched, {jira_missing} missing"
         f" | zabbix: {zabbix_matched} matched, {zabbix_missing} missing"
-        f" | ip mismatch: {ip_mismatch} | mac mismatch: {mac_mismatch}{extra}"
+        f" | ip mismatch: {ip_mismatches} | mac mismatch: {mac_mismatches}{extra}"
     )
 
 
@@ -209,6 +224,12 @@ def main() -> int:
         return 1
 
     try:
+        jira_index = build_jira_index(jira_client)
+    except RuntimeError as e:
+        logger.error("%s — aborting, nothing sent.", e)
+        return 1
+
+    try:
         zabbix_index = build_zabbix_index(
             cfg.zabbix_url, cfg.zabbix_user, cfg.zabbix_password, pool_size=RECONCILE_CONCURRENCY
         )
@@ -221,18 +242,13 @@ def main() -> int:
     total = len(all_devices)
     logger.info("Reconciling %d device(s) against Jira Assets and Zabbix...", total)
     reconciled: list[ReconciledDevice] = []
-    jira_errors = 0
     zabbix_errors = 0
     completed = 0
     with ThreadPoolExecutor(max_workers=RECONCILE_CONCURRENCY) as executor:
-        for r in executor.map(lambda d: reconcile_device(d, jira_client, zabbix_index), all_devices):
+        for r in executor.map(lambda d: reconcile_device(d, jira_index, zabbix_index), all_devices):
             completed += 1
             if completed % 250 == 0 or completed == total:
                 logger.info("Reconciled %d/%d device(s)", completed, total)
-            if r.jira_error:
-                jira_errors += 1
-                logger.warning("Jira lookup error for %r — excluded from batch", r.controller_device.name)
-                continue
             if r.zabbix_error:
                 zabbix_errors += 1
                 logger.warning(
@@ -240,7 +256,16 @@ def main() -> int:
                 )
             reconciled.append(r)
 
-    summary = build_summary(reconciled, jira_errors, zabbix_errors)
+    if jira_index.ambiguous_hits:
+        logger.warning(
+            "%d device(s) hit a value shared by two or more Jira devices and were matched on a weaker "
+            "identifier (or left unmatched) rather than guessed — fix the duplicates in Jira "
+            "(strongest affected lookup key per device, e.g. %s)",
+            len(jira_index.ambiguous_hits),
+            ", ".join(f"{method}={value!r}" for method, value in jira_index.ambiguous_hits[:5]),
+        )
+
+    summary = build_summary(reconciled, zabbix_errors)
     if args.as_json:
         # Keep stdout as pure, pipeable JSON — the summary goes to the log instead.
         print(json.dumps([build_log_data(r) for r in reconciled], indent=2))

--- a/accessparks-device-metadata/src/controllers/tarana.py
+++ b/accessparks-device-metadata/src/controllers/tarana.py
@@ -13,10 +13,10 @@ GET /api/nqs/v1/operators/{operatorId}/regions, where operatorId is the
 decoded here without signature verification since it's our own just-issued
 token, only for reading a claim). Verified live: operatorId 27 ->
 region 33 ("AccessParks") -> devices/search with ids:[33] returns real
-device rows. The device-search response DOES include macAddress (contrary
-to the tarana.go Device struct's field list) — kept as "" here anyway since
-that struct is the only documented contract and mapping an unverified field
-risks silently wrong data more than an empty mac does.
+device rows. The device-search response includes macAddress (contrary to the
+tarana.go Device struct's field list) — already colon-separated uppercase,
+verified live against the deployed regions, and mapped here so Tarana
+devices can be matched to Jira/Zabbix by MAC like every other vendor's.
 """
 
 from __future__ import annotations
@@ -132,7 +132,7 @@ class TaranaController:
                     controller=self.name,
                     name=d.get("hostName") or "",
                     ip=d.get("ip") or "",
-                    mac="",
+                    mac=(d.get("macAddress") or "").upper(),
                     serial=d.get("serialNumber") or "",
                     device_id=d.get("serialNumber") or "",
                 )

--- a/accessparks-device-metadata/src/jira_assets.py
+++ b/accessparks-device-metadata/src/jira_assets.py
@@ -1,24 +1,62 @@
 """Client for the AccessParks Asset Registry service — a local mirror of Jira
-Assets, exposing `GET /devices/{identifier}` (see
-InsightAgent/ap-jira-asset-server). This is what every existing AccessParks
-agent talks to instead of Jira Assets/AQL directly.
+Assets (see InsightAgent/ap-jira-asset-server). This is what every existing
+AccessParks agent talks to instead of Jira Assets/AQL directly.
 
-Lookup contract mirrors InsightAgent/unifi-agent/ap_inventory_lookup.py:
-  - {}   -> confirmed miss (404)
-  - None -> API/network error; caller must NOT treat this as a confirmed miss
+Matching happens against a local index built from one `GET /devices/export`
+call rather than per-device `GET /devices/{identifier}` requests. Two reasons:
+
+- Whitespace. Jira Assets device labels contain stray whitespace that the
+  controllers don't reproduce — 58 of the ~33k records have a doubled or
+  edge space (e.g. "ALBU-Ped  6-AP" for the controller's "ALBU-Ped 6-AP").
+  `/devices/{identifier}` matches exactly (case-insensitively), so no
+  identifier we could send would ever match those; the registry cannot be
+  asked to ignore whitespace. Matching locally can.
+- Cost. The registry is reached over the public internet
+  (JIRAASSET_BASE is an EC2 host), and this agent resolves ~10k devices with
+  up to 3 identifiers each. That's up to 30k internet round trips replaced
+  by a single ~3 MB gzipped fetch — which is exactly what the export
+  endpoint documents itself as being for.
+
+A failed export fetch aborts the run (same as Zabbix's bulk host fetch)
+rather than degrading into per-device "not found", so a network problem is
+never reported to InsightFinder as a fleet-wide Jira gap.
 """
 
 from __future__ import annotations
 
+import dataclasses
+import gzip
 import json
 import logging
+import re
 import urllib.error
-import urllib.parse
 import urllib.request
 
 from models import JiraMatch
 
 logger = logging.getLogger(__name__)
+
+_WHITESPACE = re.compile(r"\s+")
+
+# Values reported as jira.match_method, ordered by how much we trust them.
+# Each names the record field whose value was used as the lookup key, so a
+# reader can see exactly what was matched on rather than inferring it. The
+# key always comes from the controller here — it's the controller's device
+# that's being looked up in Jira.
+MATCH_MAC = "controller.mac"
+MATCH_SERIAL = "controller.serial"
+MATCH_NAME = "controller.device_name"
+
+
+def _exact_key(value: str) -> str:
+    return value.strip().lower()
+
+
+def _loose_key(value: str) -> str:
+    """Whitespace-insensitive form of an identifier: every whitespace run
+    removed, lowercased. "ALBU-Ped  6-AP" and "albu-ped 6-ap" collapse to the
+    same key."""
+    return _WHITESPACE.sub("", value).lower()
 
 
 class JiraAssetClient:
@@ -39,51 +77,178 @@ class JiraAssetClient:
             logger.error("Asset Registry health check failed: %s", e)
             return False
 
-    def lookup(self, identifier: str) -> dict | None:
-        """GET /devices/{identifier}. Returns the device record ({} = not
-        found) or None on request error."""
-        url = f"{self.base_url}/devices/{urllib.parse.quote(identifier, safe='')}"
+    def export_devices(self, timeout: int = 180) -> list[dict]:
+        """GET /devices/export — every device record in one call. Raises
+        RuntimeError on any failure; the caller must abort the run.
+
+        The payload's shape is checked, not assumed: a proxy or WAF in front
+        of the registry can answer 200 with a JSON *object* error envelope,
+        which would otherwise sail past this contract and fail later as an
+        AttributeError inside build_index, past main()'s RuntimeError handler.
+        """
         req = urllib.request.Request(
-            url,
-            headers={"Accept": "application/json", "X-API-Key": self.api_key},
+            f"{self.base_url}/devices/export",
+            headers={
+                "Accept": "application/json",
+                "Accept-Encoding": "gzip",
+                "X-API-Key": self.api_key,
+            },
         )
         try:
-            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
-                return json.loads(resp.read())
-        except urllib.error.HTTPError as e:
-            if e.code == 404:
-                return {}
-            logger.warning("HTTP %d looking up %r in Jira Assets", e.code, identifier)
-            return None
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read()
+                if resp.headers.get("Content-Encoding") == "gzip":
+                    raw = gzip.decompress(raw)
+            records = json.loads(raw)
         except (urllib.error.URLError, ValueError, OSError) as e:
-            logger.warning("Jira Assets request failed for %r: %s", identifier, e)
-            return None
+            raise RuntimeError(f"Jira Assets device export failed: {e}") from e
+        if not isinstance(records, list):
+            raise RuntimeError(
+                f"Jira Assets device export returned {type(records).__name__}, not a list of devices"
+            )
+        return records
 
-    def find_device(self, mac: str, serial: str, name: str) -> tuple[JiraMatch | None, bool]:
-        """Try identifiers in priority order: MAC -> serial -> name. IP is
-        deliberately excluded — it isn't stable enough to key identity on.
 
-        Stops at the first identifier that errors (same contract as
-        ap_inventory_lookup.py's find_in_inventory) so a transient failure on
-        one identifier can't be misread as "tried everything, confirmed
-        missing" — the caller must not report this device as missing.
+class JiraAssetIndex:
+    """Local, whitespace-insensitive index over the Asset Registry export.
 
-        Returns (match, had_error).
-        """
-        for ident in (mac, serial, name):
-            if not ident:
+    Identifiers are tried strongest-first — MAC, then serial, then the device
+    label — and each is looked up exactly (case-insensitively) before its
+    whitespace-stripped form. IP is deliberately not a match key: it isn't
+    stable enough to key identity on, and IP disagreement is one of the
+    things this agent exists to report. Neither is Jira's short `device_name`
+    ("AP", "GN", "GPONAP"): 29,697 of the 33k devices share one with another
+    device, and across a 2,000-device sample the unique remainder matched
+    nothing a stronger identifier hadn't already matched — so indexing it
+    only risks binding a device to an unrelated venue's asset.
+
+    Exact and whitespace-stripped keys live in separate tables so relaxing
+    whitespace can only add matches, never redirect or destroy an exact one.
+    Jira really does contain a device whose stripped label collides with a
+    different device's exact label ("DLPC-Home315-HMR"), which in a shared
+    table would take out the exact match too.
+
+    A key claimed by two or more devices is disabled rather than resolved
+    arbitrarily. Jira has 277 MACs and 180 serials sitting on more than one
+    device — placeholders like "-" and "n/a", but also real duplicates left
+    behind by device replacements. `GET /devices/{identifier}` settles those
+    with an arbitrary `LIMIT 1`; refusing the identifier and falling through
+    to the next one instead means a device is matched on a unique serial or
+    its own name rather than a coin-flipped MAC, or is honestly reported as
+    unmatched.
+    """
+
+    _METHODS = (MATCH_MAC, MATCH_SERIAL, MATCH_NAME)
+
+    def __init__(self) -> None:
+        # method -> key -> JiraMatch, or None once the key is known ambiguous.
+        self._exact: dict[str, dict[str, JiraMatch | None]] = {m: {} for m in self._METHODS}
+        self._loose: dict[str, dict[str, JiraMatch | None]] = {m: {} for m in self._METHODS}
+        # Identifier values disabled for being shared, held as
+        # (method, loose key). A set rather than a counter, and keyed on the
+        # loose form rather than the table key: each value is inserted into
+        # both the exact and the loose table, so an incrementing counter — or
+        # a set keyed on the table key, whose two forms differ whenever the
+        # value contains whitespace — would report each identifier twice.
+        self._disabled: set[tuple[str, str]] = set()
+        # One entry per device whose strongest identifier was ambiguous, so a
+        # weaker one (or nothing) had to be used — a Jira data-quality signal
+        # worth reporting per run. Appends are atomic, so no lock is needed
+        # for the concurrent reconcile workers.
+        self.ambiguous_hits: list[tuple[str, str]] = []
+
+    @property
+    def ambiguous_keys(self) -> int:
+        """Distinct identifier values disabled for being shared by two or
+        more Jira devices."""
+        return len(self._disabled)
+
+    def _put(self, table: dict[str, JiraMatch | None], key: str, match: JiraMatch) -> bool:
+        """Indexes match under key. Returns True if this call disabled the key
+        as ambiguous."""
+        if key not in table:
+            table[key] = match
+            return False
+        if table[key] is not None and table[key].object_key != match.object_key:
+            table[key] = None
+            return True
+        return False
+
+    def add(self, record: dict) -> None:
+        object_key = record.get("object_key") or ""
+        if not object_key:
+            return
+        match = JiraMatch(
+            object_key=object_key,
+            device_name=record.get("name") or record.get("device_name") or "",
+            ip=record.get("ip_address") or "",
+            mac=(record.get("mac_address") or "").upper(),
+            zabbix_host_id=record.get("zabbix_host_id") or "",
+        )
+        for method, value in (
+            (MATCH_MAC, record.get("mac_address") or ""),
+            (MATCH_SERIAL, record.get("serial_number") or ""),
+            (MATCH_NAME, record.get("name") or ""),
+        ):
+            if not value.strip():
                 continue
-            result = self.lookup(ident)
-            if result is None:
-                return None, True  # error — stop, don't treat as a miss
-            if result:
-                return (
-                    JiraMatch(
-                        object_key=result.get("object_key") or "",
-                        ip=result.get("ip_address") or "",
-                        mac=(result.get("mac_address") or "").upper(),
-                        zabbix_host_id=result.get("zabbix_host_id") or "",
-                    ),
-                    False,
-                )
-        return None, False  # all identifiers tried, all returned 404
+            disabled = self._put(self._exact[method], _exact_key(value), match)
+            disabled |= self._put(self._loose[method], _loose_key(value), match)
+            if disabled:
+                self._disabled.add((method, _loose_key(value)))
+
+    def find_device(self, mac: str, serial: str, name: str) -> JiraMatch | None:
+        """Returns the matched device with match_method filled in, or None for
+        a confirmed miss.
+
+        Records at most one ambiguous-identifier hit per call, so
+        ambiguous_hits stays a count of affected *devices* — a device with
+        both a shared MAC and a shared serial is one problem to fix, not two.
+        The hit is recorded the moment an ambiguous identifier is skipped,
+        not after the loop: a device that then matches on a weaker identifier
+        returns from inside the loop, and it's exactly those devices (matched
+        on their name because their MAC was shared) most worth reporting.
+        """
+        recorded = False
+        for method, value in (
+            (MATCH_MAC, mac),
+            (MATCH_SERIAL, serial),
+            (MATCH_NAME, name),
+        ):
+            if not value or not value.strip():
+                continue
+            ambiguous = False
+            for table, keyfn in ((self._exact, _exact_key), (self._loose, _loose_key)):
+                key = keyfn(value)
+                match = table[method].get(key)
+                if match is not None:
+                    return dataclasses.replace(match, match_method=method)
+                ambiguous = ambiguous or key in table[method]
+            if ambiguous and not recorded:
+                self.ambiguous_hits.append((method, value))
+                recorded = True
+        return None
+
+
+def build_index(client: JiraAssetClient) -> JiraAssetIndex:
+    logger.info("Fetching Jira Assets device export from %s...", client.base_url)
+    records = client.export_devices()
+    # An unsynced registry answers 200 with []. Building an empty index from
+    # that would report the entire fleet as missing from Jira — precisely the
+    # fleet-wide false gap this module's error handling exists to prevent, and
+    # no longer caught per-device now that the jira_error tri-state is gone.
+    if not records:
+        raise RuntimeError(
+            "Jira Assets device export returned 0 devices — the registry is empty or unsynced "
+            "(check its /sync/status); every device would otherwise be reported as missing from Jira"
+        )
+    index = JiraAssetIndex()
+    for record in records:
+        index.add(record)
+    logger.info(
+        "Indexed %d Jira Asset device(s) (%d ambiguous identifier(s) disabled as match keys — "
+        "values shared by two or more Jira devices, which cannot identify either)",
+        len(records),
+        index.ambiguous_keys,
+    )
+    return index

--- a/accessparks-device-metadata/src/models.py
+++ b/accessparks-device-metadata/src/models.py
@@ -23,21 +23,26 @@ class ControllerDevice:
 @dataclasses.dataclass
 class JiraMatch:
     object_key: str
+    device_name: str = ""
     ip: str = ""
     mac: str = ""
     zabbix_host_id: str = ""
+    # Human-readable identifier this device was matched on ("MAC address",
+    # "Device name", ...) — shipped to InsightFinder as jira.match_method so a
+    # weak (name-based) match is distinguishable there from a strong one.
+    match_method: str = ""
 
 
 @dataclasses.dataclass
 class ZabbixMatch:
     hostid: str
-    matched_by: str = ""
+    device_name: str = ""
+    match_method: str = ""
 
 
 @dataclasses.dataclass
 class ReconciledDevice:
     controller_device: ControllerDevice
     jira: JiraMatch | None
-    jira_error: bool
     zabbix: ZabbixMatch | None
     zabbix_error: bool = False

--- a/accessparks-device-metadata/src/reconcile.py
+++ b/accessparks-device-metadata/src/reconcile.py
@@ -8,7 +8,7 @@ import logging
 import re
 from collections import Counter
 
-from jira_assets import JiraAssetClient
+from jira_assets import JiraAssetIndex
 from models import ControllerDevice
 from models import ReconciledDevice
 from zabbix import ZabbixIndex
@@ -16,15 +16,14 @@ from zabbix import ZabbixIndex
 logger = logging.getLogger(__name__)
 
 
-def reconcile_device(device: ControllerDevice, jira_client: JiraAssetClient, zabbix_index: ZabbixIndex | None) -> ReconciledDevice:
-    jira_match, jira_error = jira_client.find_device(mac=device.mac, serial=device.serial, name=device.name)
+def reconcile_device(
+    device: ControllerDevice, jira_index: JiraAssetIndex, zabbix_index: ZabbixIndex | None
+) -> ReconciledDevice:
+    jira_match = jira_index.find_device(mac=device.mac, serial=device.serial, name=device.name)
 
     zabbix_match = None
     zabbix_error = False
-    # A Jira-lookup error makes the caller discard this record entirely, so
-    # skip the Zabbix RPC (which includes a live tag lookup) rather than
-    # spending it on a result nobody will use.
-    if zabbix_index is not None and not jira_error:
+    if zabbix_index is not None:
         zabbix_match, zabbix_error = zabbix_index.resolve(
             jira_object_key=jira_match.object_key if jira_match else "",
             jira_zabbix_host_id=jira_match.zabbix_host_id if jira_match else "",
@@ -35,11 +34,12 @@ def reconcile_device(device: ControllerDevice, jira_client: JiraAssetClient, zab
     return ReconciledDevice(
         controller_device=device,
         jira=jira_match,
-        jira_error=jira_error,
         zabbix=zabbix_match,
         zabbix_error=zabbix_error,
     )
 
+
+_WHITESPACE = re.compile(r"\s+")
 
 # InsightFinder instance-name rule: no space, ",", "_", "@", "#", ":".
 _SANITIZE_MAP = str.maketrans({" ": "-", ",": "-", "@": "-", "#": "-", "_": ".", ":": "-"})
@@ -90,7 +90,60 @@ def build_instance_tags(devices: list[ControllerDevice]) -> list[str]:
     return tags
 
 
+def _strip_whitespace(value: str) -> str:
+    """Every whitespace character removed. Used only to compare a controller
+    value against a Jira one, never to rewrite what gets shipped."""
+    return _WHITESPACE.sub("", value)
+
+
+def ip_mismatch(reconciled: ReconciledDevice) -> bool:
+    """True when the controller and Jira both report an IP and they differ.
+
+    Whitespace-insensitive, for the same reason matching is (see
+    jira_assets.JiraAssetIndex): stray spacing in a Jira field is a
+    formatting defect, not a different address, and a device matched despite
+    that whitespace must not then be reported as disagreeing with itself.
+    """
+    jira = reconciled.jira
+    if not (jira and jira.ip and reconciled.controller_device.ip):
+        return False
+    return _strip_whitespace(jira.ip) != _strip_whitespace(reconciled.controller_device.ip)
+
+
+def mac_mismatch(reconciled: ReconciledDevice) -> bool:
+    """True when the controller and Jira both report a MAC and they differ.
+    Case- and whitespace-insensitive — Jira holds MACs recorded as
+    " 48:A9:8A:9B:EA:C9" and "48:A9:8A:B6: E7:8A", which are the same
+    addresses their controllers report, not different ones."""
+    jira = reconciled.jira
+    if not (jira and jira.mac and reconciled.controller_device.mac):
+        return False
+    return (
+        _strip_whitespace(jira.mac).lower()
+        != _strip_whitespace(reconciled.controller_device.mac).lower()
+    )
+
+
 def build_log_data(reconciled: ReconciledDevice) -> dict:
+    """The InsightFinder log record for one device.
+
+    Every key is always present, with "" where a value is unknown or the
+    device wasn't found at all — a field that disappears when a device is
+    missing can't be queried or alerted on in InsightFinder, which is the
+    whole point of this agent.
+
+    Values are shipped exactly as each source reports them — whitespace
+    included. InsightFinder's ingestion rules constrain the *instance name*,
+    which build_instance_tags/sanitize_instance_name handles; the log record
+    itself is free-form, so rewriting a source's own value here would only
+    misrepresent what that source holds. Whitespace is ignored when finding
+    and comparing devices (see jira_assets.JiraAssetIndex, ip_mismatch,
+    mac_mismatch), not when reporting them.
+
+    Both match_method fields name a field of this record, so every field one
+    can name is present here — that's why controller.serial and
+    jira.zabbix_host_id are emitted even though nothing else reads them.
+    """
     d = reconciled.controller_device
     jira = reconciled.jira
     zabbix = reconciled.zabbix
@@ -98,15 +151,21 @@ def build_log_data(reconciled: ReconciledDevice) -> dict:
         "controller": {
             "name": d.controller,
             "device_name": d.name,
-            "ip": d.ip or None,
-            "mac": d.mac or None,
+            "ip": d.ip,
+            "mac": d.mac,
+            "serial": d.serial,
         },
         "jira": {
-            "id": jira.object_key if jira else None,
-            "ip": jira.ip if jira else None,
-            "mac": jira.mac if jira else None,
+            "id": jira.object_key if jira else "",
+            "device_name": jira.device_name if jira else "",
+            "ip": jira.ip if jira else "",
+            "mac": jira.mac if jira else "",
+            "zabbix_host_id": jira.zabbix_host_id if jira else "",
+            "match_method": jira.match_method if jira else "",
         },
         "zabbix": {
-            "id": zabbix.hostid if zabbix else None,
+            "id": zabbix.hostid if zabbix else "",
+            "device_name": zabbix.device_name if zabbix else "",
+            "match_method": zabbix.match_method if zabbix else "",
         },
     }

--- a/accessparks-device-metadata/src/zabbix.py
+++ b/accessparks-device-metadata/src/zabbix.py
@@ -38,6 +38,24 @@ logger = logging.getLogger(__name__)
 
 JIRA_KEY_TAG = "jira_device_key"
 
+# Values reported as zabbix.match_method, ordered by how much we trust them.
+# Each names the record field whose value was used as the lookup key. Note
+# the fallbacks key off the *controller*, not Jira: only the first two tiers
+# use anything Jira supplied.
+#   jira.id             -> matched against the Zabbix host tag jira_device_key
+#   jira.zabbix_host_id -> that hostid, if it still exists in Zabbix
+#   controller.device_name -> Zabbix host/visible name
+#   controller.ip          -> Zabbix primary-interface IP
+MATCH_JIRA_KEY = "jira.id"
+MATCH_JIRA_HOST_ID = "jira.zabbix_host_id"
+MATCH_NAME = "controller.device_name"
+MATCH_IP = "controller.ip"
+
+
+def _host_name(host: dict) -> str:
+    """Zabbix's visible name, falling back to the technical host name."""
+    return (host.get("name") or host.get("host") or "").strip()
+
 
 class ZabbixIndex:
     def __init__(self, zapi: ZabbixAPI) -> None:
@@ -84,7 +102,7 @@ class ZabbixIndex:
 
     def _lookup_by_jira_key(self, jira_object_key: str) -> tuple[dict | None, bool]:
         """Returns (host, had_error) — same tri-state contract as
-        JiraAssetClient.find_device: an error is never returned as a plain
+        the Jira/Zabbix bulk fetches: an error is never returned as a plain
         miss, so a transient blip on this per-device RPC can't be misread by
         resolve() as "confirmed absent from Zabbix"."""
         try:
@@ -124,11 +142,22 @@ class ZabbixIndex:
             if had_error:
                 return None, True
             if host:
-                return ZabbixMatch(hostid=host["hostid"], matched_by="jira_device_key"), False
+                return (
+                    ZabbixMatch(
+                        hostid=host["hostid"],
+                        device_name=_host_name(host),
+                        match_method=MATCH_JIRA_KEY,
+                    ),
+                    False,
+                )
 
         if jira_zabbix_host_id and jira_zabbix_host_id in self.by_hostid:
             return (
-                ZabbixMatch(hostid=jira_zabbix_host_id, matched_by="jira_zabbix_host_id"),
+                ZabbixMatch(
+                    hostid=jira_zabbix_host_id,
+                    device_name=_host_name(self.by_hostid[jira_zabbix_host_id]),
+                    match_method=MATCH_JIRA_HOST_ID,
+                ),
                 False,
             )
 
@@ -136,12 +165,22 @@ class ZabbixIndex:
         if name_key:
             host = self.by_name.get(name_key)
             if host:
-                return ZabbixMatch(hostid=host["hostid"], matched_by="name"), False
+                return (
+                    ZabbixMatch(
+                        hostid=host["hostid"], device_name=_host_name(host), match_method=MATCH_NAME
+                    ),
+                    False,
+                )
 
         if device_ip:
             host = self.by_ip.get(device_ip)
             if host:
-                return ZabbixMatch(hostid=host["hostid"], matched_by="ip"), False
+                return (
+                    ZabbixMatch(
+                        hostid=host["hostid"], device_name=_host_name(host), match_method=MATCH_IP
+                    ),
+                    False,
+                )
 
         return None, False
 
@@ -194,6 +233,16 @@ def build_index(
         )["result"]
     except ZABBIX_ERRORS as e:
         raise RuntimeError(f"Zabbix host.get failed: {e}") from e
+
+    # Same hazard as an empty Jira export (see jira_assets.build_index): this
+    # instance has ~31k hosts, so an empty result is a broken query or a
+    # permissions change, not a genuinely empty Zabbix — and indexing it would
+    # report every device as missing from Zabbix.
+    if not hosts:
+        raise RuntimeError(
+            "Zabbix host.get returned 0 hosts — every device would otherwise be reported as "
+            "missing from Zabbix"
+        )
 
     index = ZabbixIndex(zapi)
     for host in hosts:


### PR DESCRIPTION
https://insightfinders.atlassian.net/browse/II-24680

New requirement:

Still keep the empty fields even we can't find them.

Add a new json field called match_method in both jira and zabbix to imply how we match the records. Example values: MAC address, Device name.

Show the device name found in the jira and zabbix field as well.

Ignore the whitespaces when finding the devices in jira.

Some Tarana devices are missing MAC addresses. Please include MAC address for Tarana devices.